### PR TITLE
Error taxonomy in FINAL lines + deterministic burst (benchmark harness)

### DIFF
--- a/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
@@ -10,7 +10,10 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::time;
 use tokio_tungstenite::tungstenite::Message;
 
-use arcane_swarm::{player_state_json, ArcaneEndpoint, Metrics, Player};
+use arcane_swarm::{
+    is_zone_event_active, player_state_json, ArcaneEndpoint, BurstConfig, ErrorKind, Metrics,
+    Player,
+};
 
 #[derive(serde::Deserialize)]
 struct ManagerJoinResponse {
@@ -81,6 +84,8 @@ pub(crate) struct ArcanePlayerLoop {
     pub read_metrics: Arc<Metrics>,
     pub stop: Arc<AtomicBool>,
     pub cluster_flag: Arc<AtomicBool>,
+    pub burst: BurstConfig,
+    pub run_started: std::time::Instant,
 }
 
 pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
@@ -95,6 +100,8 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
         read_metrics,
         stop,
         cluster_flag,
+        burst,
+        run_started,
     } = ctx;
 
     let ws_url = resolve_arcane_ws(&endpoint, &client, idx).await;
@@ -108,7 +115,7 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
             if idx == 0 {
                 eprintln!("[player 0] WebSocket connect failed: {}", e);
             }
-            metrics.record_err();
+            metrics.record_err_kind(ErrorKind::NotDelivered);
             return;
         }
     };
@@ -126,7 +133,10 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
                     rm.record_inbound_ok(bin.len() as u64);
                 }
                 Some(Ok(_)) => {}
-                _ => break,
+                _ => {
+                    rm.record_err_kind(ErrorKind::ConnectionDrop);
+                    break;
+                }
             }
         }
     });
@@ -136,6 +146,9 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
 
     while !stop.load(Ordering::Relaxed) {
         interval.tick().await;
+        if is_zone_event_active(run_started.elapsed().as_millis() as u64, burst) {
+            player.steer_to_point(2500.0, 2500.0);
+        }
         player.tick(tick_dt, cluster_flag.load(Ordering::Relaxed));
         let msg = player_state_json(
             &player.id, player.x, player.y, player.z, player.vx, player.vy, player.vz,
@@ -146,7 +159,7 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
                 metrics.record_ok(t0.elapsed());
             }
             Err(e) => {
-                metrics.record_err();
+                metrics.record_err_kind(ErrorKind::NotDelivered);
                 if idx == 0 {
                     eprintln!("[player 0] ws send error: {}", e);
                 }

--- a/crates/arcane-swarm/src/bin/arcane_swarm/backends_spacetimedb.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/backends_spacetimedb.rs
@@ -8,7 +8,10 @@ use std::time::{Duration, Instant};
 
 use tokio::time;
 
-use arcane_swarm::{Metrics, Player, VISIBILITY_RADIUS};
+use arcane_swarm::{
+    burst_actions_to_emit, is_zone_event_active, BurstConfig, ErrorKind, Metrics, Player,
+    VISIBILITY_RADIUS,
+};
 
 fn uuid_json(id: &uuid::Uuid) -> u128 {
     u128::from_be_bytes(*id.as_bytes())
@@ -129,6 +132,8 @@ pub(crate) struct SpacetimeActionLoop {
     pub actions_per_sec: f64,
     pub action_metrics: Arc<Metrics>,
     pub stop: Arc<AtomicBool>,
+    pub burst: BurstConfig,
+    pub run_started: Instant,
 }
 
 pub(crate) async fn action_loop(ctx: SpacetimeActionLoop) {
@@ -142,6 +147,8 @@ pub(crate) async fn action_loop(ctx: SpacetimeActionLoop) {
         actions_per_sec,
         action_metrics,
         stop,
+        burst,
+        run_started,
     } = ctx;
 
     if actions_per_sec <= 0.0 {
@@ -157,54 +164,65 @@ pub(crate) async fn action_loop(ctx: SpacetimeActionLoop) {
         tick += 1;
         let total_now = total_players.load(Ordering::Relaxed);
         let action = random_action(player_idx, total_now, tick);
-
-        let (url, body) = match action {
-            GameAction::PickupItem {
-                item_type,
-                quantity,
-            } => (
-                &urls.pickup,
-                pickup_item_json(&player_id, item_type, quantity),
-            ),
-            GameAction::UseItem { item_type } => {
-                (&urls.use_item, use_item_json(&player_id, item_type))
-            }
-            GameAction::Interact {
-                target_idx,
-                event_type,
-            } => {
-                let target = all_ids
-                    .get(target_idx as usize)
-                    .copied()
-                    .unwrap_or(player_id);
-                (
-                    &urls.interact,
-                    interact_json(&player_id, &target, event_type),
-                )
-            }
-        };
-
-        let t0 = Instant::now();
-        match client
-            .post(url.as_str())
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send()
-            .await
-        {
-            Ok(resp) if resp.status().is_success() => {
-                action_metrics.record_ok(t0.elapsed());
-            }
-            Ok(resp) => {
-                action_metrics.record_err();
-                if player_idx == 0 {
-                    let s = resp.status();
-                    let t = resp.text().await.unwrap_or_default();
-                    eprintln!("[player 0 action] HTTP {}: {}", s, &t[..t.len().min(200)]);
+        let mut burst_remaining =
+            burst_actions_to_emit(player_idx, run_started.elapsed().as_millis() as u64, burst);
+        if burst_remaining == 0 {
+            burst_remaining = 1;
+        }
+        for _ in 0..burst_remaining {
+            let (url, body) = match action {
+                GameAction::PickupItem {
+                    item_type,
+                    quantity,
+                } => (
+                    &urls.pickup,
+                    pickup_item_json(&player_id, item_type, quantity),
+                ),
+                GameAction::UseItem { item_type } => {
+                    (&urls.use_item, use_item_json(&player_id, item_type))
                 }
-            }
-            Err(_) => {
-                action_metrics.record_err();
+                GameAction::Interact {
+                    target_idx,
+                    event_type,
+                } => {
+                    let target = all_ids
+                        .get(target_idx as usize)
+                        .copied()
+                        .unwrap_or(player_id);
+                    (
+                        &urls.interact,
+                        interact_json(&player_id, &target, event_type),
+                    )
+                }
+            };
+
+            let t0 = Instant::now();
+            match client
+                .post(url.as_str())
+                .header("Content-Type", "application/json")
+                .body(body)
+                .send()
+                .await
+            {
+                Ok(resp) if resp.status().is_success() => {
+                    action_metrics.record_ok(t0.elapsed());
+                }
+                Ok(resp) => {
+                    action_metrics.record_err_kind(ErrorKind::HttpStatus);
+                    if player_idx == 0 {
+                        let s = resp.status();
+                        let t = resp.text().await.unwrap_or_default();
+                        eprintln!("[player 0 action] HTTP {}: {}", s, &t[..t.len().min(200)]);
+                    }
+                }
+                Err(e) => {
+                    let kind = if e.is_timeout() {
+                        ErrorKind::Timeout
+                    } else {
+                        ErrorKind::Transport
+                    };
+                    action_metrics.record_err_kind(kind);
+                }
             }
         }
     }
@@ -262,15 +280,20 @@ pub(crate) async fn read_loop_spacetimedb(ctx: SpacetimeReadLoop) {
                 read_metrics.record_ok_bytes(t0.elapsed(), bytes);
             }
             Ok(resp) => {
-                read_metrics.record_err();
+                read_metrics.record_err_kind(ErrorKind::HttpStatus);
                 if player_idx == 0 {
                     let s = resp.status();
                     let t = resp.text().await.unwrap_or_default();
                     eprintln!("[player 0 read] HTTP {}: {}", s, &t[..t.len().min(200)]);
                 }
             }
-            Err(_) => {
-                read_metrics.record_err();
+            Err(e) => {
+                let kind = if e.is_timeout() {
+                    ErrorKind::Timeout
+                } else {
+                    ErrorKind::Transport
+                };
+                read_metrics.record_err_kind(kind);
             }
         }
     }
@@ -291,6 +314,8 @@ pub(crate) struct SpacetimePlayerLoop {
     pub cluster_flag: Arc<AtomicBool>,
     pub server_physics: bool,
     pub positions: Arc<SharedPositions>,
+    pub burst: BurstConfig,
+    pub run_started: Instant,
 }
 
 pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
@@ -308,6 +333,8 @@ pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
         cluster_flag,
         server_physics,
         positions,
+        burst,
+        run_started,
     } = ctx;
 
     let clustered = cluster_flag.load(Ordering::Relaxed);
@@ -320,6 +347,9 @@ pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
     let mut first_tick = true;
     while !stop.load(Ordering::Relaxed) {
         interval.tick().await;
+        if is_zone_event_active(run_started.elapsed().as_millis() as u64, burst) {
+            player.steer_to_point(2500.0, 2500.0);
+        }
         player.tick(tick_dt, cluster_flag.load(Ordering::Relaxed));
         positions.set(idx, player.x, player.z);
         let t0 = Instant::now();
@@ -339,7 +369,7 @@ pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
                         metrics.record_ok(t0.elapsed());
                     }
                     Ok(resp) => {
-                        metrics.record_err();
+                        metrics.record_err_kind(ErrorKind::HttpStatus);
                         if idx == 0 {
                             let s = resp.status();
                             let t = resp.text().await.unwrap_or_default();
@@ -347,7 +377,12 @@ pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
                         }
                     }
                     Err(e) => {
-                        metrics.record_err();
+                        let kind = if e.is_timeout() {
+                            ErrorKind::Timeout
+                        } else {
+                            ErrorKind::Transport
+                        };
+                        metrics.record_err_kind(kind);
                         if idx == 0 {
                             eprintln!("[player 0] error: {}", e);
                         }
@@ -367,7 +402,7 @@ pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
                         metrics.record_ok(t0.elapsed());
                     }
                     Ok(resp) => {
-                        metrics.record_err();
+                        metrics.record_err_kind(ErrorKind::HttpStatus);
                         if idx == 0 {
                             let s = resp.status();
                             let t = resp.text().await.unwrap_or_default();
@@ -375,7 +410,12 @@ pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
                         }
                     }
                     Err(e) => {
-                        metrics.record_err();
+                        let kind = if e.is_timeout() {
+                            ErrorKind::Timeout
+                        } else {
+                            ErrorKind::Transport
+                        };
+                        metrics.record_err_kind(kind);
                         if idx == 0 {
                             eprintln!("[player 0] error: {}", e);
                         }
@@ -397,7 +437,7 @@ pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
                     metrics.record_ok(t0.elapsed());
                 }
                 Ok(resp) => {
-                    metrics.record_err();
+                    metrics.record_err_kind(ErrorKind::HttpStatus);
                     if idx == 0 {
                         let s = resp.status();
                         let t = resp.text().await.unwrap_or_default();
@@ -405,7 +445,12 @@ pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
                     }
                 }
                 Err(e) => {
-                    metrics.record_err();
+                    let kind = if e.is_timeout() {
+                        ErrorKind::Timeout
+                    } else {
+                        ErrorKind::Transport
+                    };
+                    metrics.record_err_kind(kind);
                     if idx == 0 {
                         eprintln!("[player 0] error: {}", e);
                     }

--- a/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
@@ -85,6 +85,8 @@ impl BackendRuntime for SpacetimeRuntime {
                 cluster_flag: shared.cluster_flag.clone(),
                 server_physics: self.server_physics,
                 positions: shared.positions.clone(),
+                burst: shared.burst,
+                run_started: shared.run_started,
             },
         ))
     }
@@ -138,6 +140,8 @@ impl BackendRuntime for ArcaneRuntime {
                 read_metrics: shared.read_metrics.clone(),
                 stop: params.stop,
                 cluster_flag: shared.cluster_flag.clone(),
+                burst: shared.burst,
+                run_started: shared.run_started,
             },
         ))
     }
@@ -153,6 +157,7 @@ impl BackendRuntime for ArcaneRuntime {
 }
 
 async fn run_control_mode(cfg: Config, tick_interval: Duration) {
+    let run_started = std::time::Instant::now();
     let stdb_base = cfg.spacetimedb_uri.trim_end_matches('/').to_string();
     let base = format!("{}/v1/database/{}/call", stdb_base, cfg.database);
     let sql_url = format!("{}/v1/database/{}/sql", stdb_base, cfg.database);
@@ -176,7 +181,7 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
     };
     let backend_name = backend_runtime.name();
     eprintln!(
-        "arcane-swarm(control): initial_players={}, max_players={}, tick_rate={}, mode={}, backend={}, server_physics={}, actions/s={:.1}, read_rate={:.1}Hz control_port={}",
+        "arcane-swarm(control): initial_players={}, max_players={}, tick_rate={}, mode={}, backend={}, server_physics={}, actions/s={:.1}, read_rate={:.1}Hz burst_enabled={} control_port={}",
         cfg.players,
         cfg.max_players,
         cfg.tick_rate,
@@ -185,6 +190,7 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
         cfg.server_physics,
         cfg.actions_per_sec,
         cfg.read_rate,
+        cfg.burst.enabled,
         cfg.control_port
     );
 
@@ -243,6 +249,8 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
         read_metrics: read_metrics.clone(),
         cluster_flag: cluster_flag.clone(),
         positions: positions.clone(),
+        burst: cfg.burst,
+        run_started,
     };
 
     // Spawn initial players (and their optional read/action tasks).
@@ -407,8 +415,13 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
                         0.0
                     };
                     eprintln!(
-                        "FINAL: players={} total_calls={} total_oks={} total_errs={} lat_avg_ms={:.2}",
-                        players, total_calls, snap.ok, snap.err, lat_avg_ms
+                        "FINAL: players={} total_calls={} total_oks={} total_errs={} lat_avg_ms={:.2} err_json={}",
+                        players,
+                        total_calls,
+                        snap.ok,
+                        snap.err,
+                        lat_avg_ms,
+                        snap.errors.to_json(),
                     );
                 }
                 "QUIT" => {
@@ -432,6 +445,7 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
 #[tokio::main]
 async fn main() {
     let cfg = parse_args();
+    let run_started = std::time::Instant::now();
     let tick_interval = Duration::from_micros(1_000_000 / cfg.tick_rate as u64);
     let stdb_base = cfg.spacetimedb_uri.trim_end_matches('/').to_string();
     let base = format!("{}/v1/database/{}/call", stdb_base, cfg.database);
@@ -466,6 +480,17 @@ async fn main() {
         if cfg.mode == SwarmMode::Clustered { "clustered" } else { "spread" },
         backend_name, cfg.server_physics, cfg.duration_secs, cfg.actions_per_sec, cfg.read_rate,
     );
+    if cfg.burst.enabled {
+        eprintln!(
+            "  Burst profile: period={}s cohort={}%% actions/player={} window={}ms zone_period={}s zone_window={}ms",
+            cfg.burst.burst_period_secs,
+            cfg.burst.burst_cohort_percent,
+            cfg.burst.burst_actions_per_player,
+            cfg.burst.burst_window_ms,
+            cfg.burst.zone_event_period_secs,
+            cfg.burst.zone_event_window_ms,
+        );
+    }
 
     let metrics = Arc::new(Metrics::new());
     let action_metrics = Arc::new(Metrics::new());
@@ -517,6 +542,8 @@ async fn main() {
         read_metrics: read_metrics.clone(),
         cluster_flag: cfg.cluster_command.clone(),
         positions: positions.clone(),
+        burst: cfg.burst,
+        run_started,
     };
 
     for i in 0..cfg.players {
@@ -549,6 +576,8 @@ async fn main() {
                     actions_per_sec: cfg.actions_per_sec,
                     action_metrics: action_metrics.clone(),
                     stop: stop.clone(),
+                    burst: cfg.burst,
+                    run_started,
                 },
             )));
         }

--- a/crates/arcane-swarm/src/bin/arcane_swarm/spawn_context.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/spawn_context.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use arcane_swarm::Metrics;
+use arcane_swarm::{BurstConfig, Metrics};
 
 use super::backends_spacetimedb;
 
@@ -17,6 +17,8 @@ pub(crate) struct PlayerLoopShared {
     pub read_metrics: Arc<Metrics>,
     pub cluster_flag: Arc<AtomicBool>,
     pub positions: Arc<backends_spacetimedb::SharedPositions>,
+    pub burst: BurstConfig,
+    pub run_started: std::time::Instant,
 }
 
 /// Values that differ per player (or change when control port adjusts player count).
@@ -85,6 +87,8 @@ pub(crate) fn spawn_control_mode_player(
                 actions_per_sec: kit.actions_per_sec,
                 action_metrics: kit.action_metrics.clone(),
                 stop,
+                burst: kit.loop_shared.burst,
+                run_started: kit.loop_shared.run_started,
             },
         )));
     }

--- a/crates/arcane-swarm/src/burst.rs
+++ b/crates/arcane-swarm/src/burst.rs
@@ -1,0 +1,92 @@
+//! Deterministic burst-pattern helpers shared across backends.
+
+#[derive(Clone, Copy, Debug)]
+pub struct BurstConfig {
+    pub enabled: bool,
+    pub burst_period_secs: u64,
+    pub burst_cohort_percent: u32,
+    pub burst_actions_per_player: u32,
+    pub burst_window_ms: u64,
+    pub zone_event_period_secs: u64,
+    pub zone_event_window_ms: u64,
+}
+
+impl Default for BurstConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            burst_period_secs: 30,
+            burst_cohort_percent: 20,
+            burst_actions_per_player: 10,
+            burst_window_ms: 500,
+            zone_event_period_secs: 30,
+            zone_event_window_ms: 500,
+        }
+    }
+}
+
+pub fn is_zone_event_active(now_ms: u64, cfg: BurstConfig) -> bool {
+    if !cfg.enabled || cfg.zone_event_period_secs == 0 || cfg.zone_event_window_ms == 0 {
+        return false;
+    }
+    let period_ms = cfg.zone_event_period_secs.saturating_mul(1000);
+    if period_ms == 0 {
+        return false;
+    }
+    now_ms % period_ms < cfg.zone_event_window_ms
+}
+
+pub fn burst_actions_to_emit(player_idx: u32, now_ms: u64, cfg: BurstConfig) -> u32 {
+    if !cfg.enabled
+        || cfg.burst_period_secs == 0
+        || cfg.burst_window_ms == 0
+        || cfg.burst_actions_per_player == 0
+    {
+        return 0;
+    }
+    let period_ms = cfg.burst_period_secs.saturating_mul(1000);
+    if period_ms == 0 {
+        return 0;
+    }
+    if now_ms % period_ms >= cfg.burst_window_ms {
+        return 0;
+    }
+    let cohort = cfg.burst_cohort_percent.min(100);
+    if cohort == 0 {
+        return 0;
+    }
+    // Deterministic cohort membership rotates every burst period.
+    let burst_index = now_ms / period_ms;
+    let selector = (player_idx as u64 + burst_index) % 100;
+    if selector < cohort as u64 {
+        cfg.burst_actions_per_player
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn burst_is_deterministic_for_same_time() {
+        let cfg = BurstConfig {
+            enabled: true,
+            ..BurstConfig::default()
+        };
+        let a = burst_actions_to_emit(7, 30_100, cfg);
+        let b = burst_actions_to_emit(7, 30_100, cfg);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn zone_event_window_matches_period() {
+        let cfg = BurstConfig {
+            enabled: true,
+            ..BurstConfig::default()
+        };
+        assert!(is_zone_event_active(30_100, cfg));
+        assert!(!is_zone_event_active(31_000, cfg));
+    }
+}

--- a/crates/arcane-swarm/src/config.rs
+++ b/crates/arcane-swarm/src/config.rs
@@ -3,9 +3,9 @@
 //! This module is the entry contract between operators/benchmark scripts and runtime behavior:
 //! every flag/env var eventually maps into [`Config`], which is consumed by binary orchestration.
 
+use crate::BurstConfig;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use crate::BurstConfig;
 
 /// How each player resolves the Arcane cluster WebSocket URL.
 #[derive(Clone)]
@@ -160,8 +160,7 @@ pub fn parse_args() -> Config {
             }
             "--burst-cohort-percent" => {
                 i += 1;
-                burst.burst_cohort_percent =
-                    args[i].parse().unwrap_or(burst.burst_cohort_percent);
+                burst.burst_cohort_percent = args[i].parse().unwrap_or(burst.burst_cohort_percent);
             }
             "--burst-actions-per-player" => {
                 i += 1;
@@ -179,8 +178,7 @@ pub fn parse_args() -> Config {
             }
             "--zone-event-window-ms" => {
                 i += 1;
-                burst.zone_event_window_ms =
-                    args[i].parse().unwrap_or(burst.zone_event_window_ms);
+                burst.zone_event_window_ms = args[i].parse().unwrap_or(burst.zone_event_window_ms);
             }
             "--help" | "-h" => {
                 eprintln!("arcane-swarm: headless client swarm\n");
@@ -202,9 +200,13 @@ pub fn parse_args() -> Config {
                 eprintln!("  --burst-enabled      enable deterministic burst profile (default on)");
                 eprintln!("  --burst-disabled     disable deterministic burst profile");
                 eprintln!("  --burst-period-secs N    seconds between bursts (default 30)");
-                eprintln!("  --burst-cohort-percent N percentage of players in each burst (default 20)");
+                eprintln!(
+                    "  --burst-cohort-percent N percentage of players in each burst (default 20)"
+                );
                 eprintln!("  --burst-actions-per-player N extra actions for selected players during burst (default 10)");
-                eprintln!("  --burst-window-ms N     burst window length in milliseconds (default 500)");
+                eprintln!(
+                    "  --burst-window-ms N     burst window length in milliseconds (default 500)"
+                );
                 eprintln!("  --zone-event-period-secs N seconds between all-player convergence events (default 30)");
                 eprintln!("  --zone-event-window-ms N zone event steering window in milliseconds (default 500)");
                 eprintln!("  --csv PATH             write metrics CSV to this file");

--- a/crates/arcane-swarm/src/config.rs
+++ b/crates/arcane-swarm/src/config.rs
@@ -5,6 +5,7 @@
 
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use crate::BurstConfig;
 
 /// How each player resolves the Arcane cluster WebSocket URL.
 #[derive(Clone)]
@@ -50,6 +51,7 @@ pub struct Config {
     pub server_physics: bool,
     pub run_forever: bool,
     pub control_port: u16,
+    pub burst: BurstConfig,
 }
 
 pub fn parse_args() -> Config {
@@ -70,6 +72,7 @@ pub fn parse_args() -> Config {
     let mut server_physics: bool = false;
     let mut run_forever: bool = false;
     let mut control_port: u16 = 0;
+    let mut burst = BurstConfig::default();
 
     let args: Vec<String> = std::env::args().collect();
     let mut i = 1;
@@ -145,6 +148,40 @@ pub fn parse_args() -> Config {
                 i += 1;
                 control_port = args[i].parse().unwrap_or(0);
             }
+            "--burst-enabled" => {
+                burst.enabled = true;
+            }
+            "--burst-disabled" => {
+                burst.enabled = false;
+            }
+            "--burst-period-secs" => {
+                i += 1;
+                burst.burst_period_secs = args[i].parse().unwrap_or(burst.burst_period_secs);
+            }
+            "--burst-cohort-percent" => {
+                i += 1;
+                burst.burst_cohort_percent =
+                    args[i].parse().unwrap_or(burst.burst_cohort_percent);
+            }
+            "--burst-actions-per-player" => {
+                i += 1;
+                burst.burst_actions_per_player =
+                    args[i].parse().unwrap_or(burst.burst_actions_per_player);
+            }
+            "--burst-window-ms" => {
+                i += 1;
+                burst.burst_window_ms = args[i].parse().unwrap_or(burst.burst_window_ms);
+            }
+            "--zone-event-period-secs" => {
+                i += 1;
+                burst.zone_event_period_secs =
+                    args[i].parse().unwrap_or(burst.zone_event_period_secs);
+            }
+            "--zone-event-window-ms" => {
+                i += 1;
+                burst.zone_event_window_ms =
+                    args[i].parse().unwrap_or(burst.zone_event_window_ms);
+            }
             "--help" | "-h" => {
                 eprintln!("arcane-swarm: headless client swarm\n");
                 eprintln!("  --backend MODE        spacetimedb | arcane (default spacetimedb)");
@@ -162,6 +199,14 @@ pub fn parse_args() -> Config {
                 eprintln!("  --server-physics      for spacetimedb backend: use update_player_input for movement");
                 eprintln!("  --run-forever          keep running until QUIT");
                 eprintln!("  --control-port PORT   enable TCP control server at 127.0.0.1:PORT");
+                eprintln!("  --burst-enabled      enable deterministic burst profile (default on)");
+                eprintln!("  --burst-disabled     disable deterministic burst profile");
+                eprintln!("  --burst-period-secs N    seconds between bursts (default 30)");
+                eprintln!("  --burst-cohort-percent N percentage of players in each burst (default 20)");
+                eprintln!("  --burst-actions-per-player N extra actions for selected players during burst (default 10)");
+                eprintln!("  --burst-window-ms N     burst window length in milliseconds (default 500)");
+                eprintln!("  --zone-event-period-secs N seconds between all-player convergence events (default 30)");
+                eprintln!("  --zone-event-window-ms N zone event steering window in milliseconds (default 500)");
                 eprintln!("  --csv PATH             write metrics CSV to this file");
                 eprintln!(
                     "  --uri URL              SpacetimeDB URI (default http://127.0.0.1:3000)"
@@ -198,5 +243,6 @@ pub fn parse_args() -> Config {
         server_physics,
         run_forever,
         control_port,
+        burst,
     }
 }

--- a/crates/arcane-swarm/src/lib.rs
+++ b/crates/arcane-swarm/src/lib.rs
@@ -14,8 +14,8 @@
 //! - `engine_api`: embedding contract for tooling that drives swarm runs programmatically.
 //! - `orchestration`: backend-agnostic control-mode scaling logic with mock-friendly tests.
 
-pub mod config;
 pub mod burst;
+pub mod config;
 pub mod engine_api;
 pub mod metrics;
 pub mod orchestration;
@@ -23,8 +23,8 @@ pub mod player;
 pub mod protocol;
 pub mod reporter;
 
-pub use config::{parse_args, ArcaneEndpoint, Backend, Config, SwarmMode};
 pub use burst::{burst_actions_to_emit, is_zone_event_active, BurstConfig};
+pub use config::{parse_args, ArcaneEndpoint, Backend, Config, SwarmMode};
 pub use engine_api::{EngineRunConfig, EngineRunHandle, EngineSummary, SwarmEngine};
 pub use metrics::{ErrorBreakdown, ErrorKind, Metrics, MetricsSnapshot};
 pub use player::Player;

--- a/crates/arcane-swarm/src/lib.rs
+++ b/crates/arcane-swarm/src/lib.rs
@@ -15,6 +15,7 @@
 //! - `orchestration`: backend-agnostic control-mode scaling logic with mock-friendly tests.
 
 pub mod config;
+pub mod burst;
 pub mod engine_api;
 pub mod metrics;
 pub mod orchestration;
@@ -23,8 +24,9 @@ pub mod protocol;
 pub mod reporter;
 
 pub use config::{parse_args, ArcaneEndpoint, Backend, Config, SwarmMode};
+pub use burst::{burst_actions_to_emit, is_zone_event_active, BurstConfig};
 pub use engine_api::{EngineRunConfig, EngineRunHandle, EngineSummary, SwarmEngine};
-pub use metrics::{Metrics, MetricsSnapshot};
+pub use metrics::{ErrorBreakdown, ErrorKind, Metrics, MetricsSnapshot};
 pub use player::Player;
 pub use protocol::{player_state_json, VISIBILITY_RADIUS};
 pub use reporter::{fmt_bytes, run_reporter, ReporterConfig};

--- a/crates/arcane-swarm/src/metrics.rs
+++ b/crates/arcane-swarm/src/metrics.rs
@@ -47,11 +47,7 @@ pub struct ErrorBreakdown {
 
 impl ErrorBreakdown {
     pub fn total(&self) -> u64 {
-        self.timeout
-            + self.not_delivered
-            + self.http_status
-            + self.transport
-            + self.connection_drop
+        self.timeout + self.not_delivered + self.http_status + self.transport + self.connection_drop
     }
 
     pub fn to_json(self) -> String {

--- a/crates/arcane-swarm/src/metrics.rs
+++ b/crates/arcane-swarm/src/metrics.rs
@@ -5,6 +5,67 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+/// Explicit benchmark error taxonomy.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ErrorKind {
+    Timeout,
+    NotDelivered,
+    HttpStatus,
+    Transport,
+    ConnectionDrop,
+}
+
+impl ErrorKind {
+    pub const ALL: [ErrorKind; 5] = [
+        ErrorKind::Timeout,
+        ErrorKind::NotDelivered,
+        ErrorKind::HttpStatus,
+        ErrorKind::Transport,
+        ErrorKind::ConnectionDrop,
+    ];
+
+    pub fn key(self) -> &'static str {
+        match self {
+            ErrorKind::Timeout => "timeout",
+            ErrorKind::NotDelivered => "not_delivered",
+            ErrorKind::HttpStatus => "http_status",
+            ErrorKind::Transport => "transport",
+            ErrorKind::ConnectionDrop => "connection_drop",
+        }
+    }
+}
+
+/// Per-category error counters emitted in summaries.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ErrorBreakdown {
+    pub timeout: u64,
+    pub not_delivered: u64,
+    pub http_status: u64,
+    pub transport: u64,
+    pub connection_drop: u64,
+}
+
+impl ErrorBreakdown {
+    pub fn total(&self) -> u64 {
+        self.timeout
+            + self.not_delivered
+            + self.http_status
+            + self.transport
+            + self.connection_drop
+    }
+
+    pub fn to_json(self) -> String {
+        format!(
+            "{{\"timeout\":{},\"not_delivered\":{},\"http_status\":{},\"transport\":{},\"connection_drop\":{}}}",
+            self.timeout,
+            self.not_delivered,
+            self.http_status,
+            self.transport,
+            self.connection_drop
+        )
+    }
+}
+
 /// Aggregated stats; produced by [`Metrics::snapshot_and_reset`].
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MetricsSnapshot {
@@ -15,6 +76,7 @@ pub struct MetricsSnapshot {
     pub latency_sum_us: u64,
     pub latency_samples: u64,
     pub bytes: u64,
+    pub errors: ErrorBreakdown,
 }
 
 /// Thread-safe rolling metrics for OK/err counts and latencies (microseconds).
@@ -25,6 +87,11 @@ pub struct Metrics {
     latency_max_us: AtomicU64,
     latency_samples: AtomicU64,
     bytes: AtomicU64,
+    err_timeout: AtomicU64,
+    err_not_delivered: AtomicU64,
+    err_http_status: AtomicU64,
+    err_transport: AtomicU64,
+    err_connection_drop: AtomicU64,
 }
 
 impl Metrics {
@@ -36,6 +103,11 @@ impl Metrics {
             latency_max_us: AtomicU64::new(0),
             latency_samples: AtomicU64::new(0),
             bytes: AtomicU64::new(0),
+            err_timeout: AtomicU64::new(0),
+            err_not_delivered: AtomicU64::new(0),
+            err_http_status: AtomicU64::new(0),
+            err_transport: AtomicU64::new(0),
+            err_connection_drop: AtomicU64::new(0),
         }
     }
 
@@ -53,7 +125,28 @@ impl Metrics {
     }
 
     pub fn record_err(&self) {
+        self.record_err_kind(ErrorKind::Transport);
+    }
+
+    pub fn record_err_kind(&self, kind: ErrorKind) {
         self.err.fetch_add(1, Ordering::Relaxed);
+        match kind {
+            ErrorKind::Timeout => {
+                self.err_timeout.fetch_add(1, Ordering::Relaxed);
+            }
+            ErrorKind::NotDelivered => {
+                self.err_not_delivered.fetch_add(1, Ordering::Relaxed);
+            }
+            ErrorKind::HttpStatus => {
+                self.err_http_status.fetch_add(1, Ordering::Relaxed);
+            }
+            ErrorKind::Transport => {
+                self.err_transport.fetch_add(1, Ordering::Relaxed);
+            }
+            ErrorKind::ConnectionDrop => {
+                self.err_connection_drop.fetch_add(1, Ordering::Relaxed);
+            }
+        }
     }
 
     /// One successful inbound message (e.g. WebSocket frame), counted as an OK with payload bytes.
@@ -70,6 +163,13 @@ impl Metrics {
         let n = self.latency_samples.swap(0, Ordering::Relaxed);
         let avg = if n > 0 { sum / n } else { 0 };
         let bytes = self.bytes.swap(0, Ordering::Relaxed);
+        let errors = ErrorBreakdown {
+            timeout: self.err_timeout.swap(0, Ordering::Relaxed),
+            not_delivered: self.err_not_delivered.swap(0, Ordering::Relaxed),
+            http_status: self.err_http_status.swap(0, Ordering::Relaxed),
+            transport: self.err_transport.swap(0, Ordering::Relaxed),
+            connection_drop: self.err_connection_drop.swap(0, Ordering::Relaxed),
+        };
         MetricsSnapshot {
             ok,
             err,
@@ -78,6 +178,7 @@ impl Metrics {
             latency_sum_us: sum,
             latency_samples: n,
             bytes,
+            errors,
         }
     }
 }
@@ -98,11 +199,15 @@ mod tests {
         let m = Metrics::new();
         m.record_ok(Duration::from_micros(100));
         m.record_inbound_ok(42);
+        m.record_err_kind(ErrorKind::Timeout);
         let s = m.snapshot_and_reset();
         assert_eq!(s.ok, 2);
         assert_eq!(s.bytes, 42);
+        assert_eq!(s.errors.timeout, 1);
+        assert_eq!(s.errors.total(), 1);
         let s2 = m.snapshot_and_reset();
         assert_eq!(s2.ok, 0);
         assert_eq!(s2.bytes, 0);
+        assert_eq!(s2.errors.total(), 0);
     }
 }

--- a/crates/arcane-swarm/src/player.rs
+++ b/crates/arcane-swarm/src/player.rs
@@ -81,6 +81,16 @@ impl Player {
             self.dir_z = -self.dir_z.abs();
         }
     }
+
+    pub fn steer_to_point(&mut self, target_x: f64, target_z: f64) {
+        let dx = target_x - self.x;
+        let dz = target_z - self.z;
+        let norm = (dx * dx + dz * dz).sqrt();
+        if norm > 0.0001 {
+            self.dir_x = dx / norm;
+            self.dir_z = dz / norm;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/arcane-swarm/src/reporter.rs
+++ b/crates/arcane-swarm/src/reporter.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use tokio::time;
 
-use crate::metrics::{Metrics, MetricsSnapshot};
+use crate::metrics::{ErrorBreakdown, Metrics, MetricsSnapshot};
 
 /// Arguments for [`run_reporter`].
 pub struct ReporterConfig<'a> {
@@ -56,6 +56,7 @@ pub async fn run_reporter(cfg: ReporterConfig<'_>) {
     let mut total_calls: u64 = 0;
     let mut total_latency_sum_us: u64 = 0;
     let mut total_latency_samples: u64 = 0;
+    let mut total_errors = ErrorBreakdown::default();
     let mut total_action_calls: u64 = 0;
     let mut total_action_oks: u64 = 0;
     let mut total_action_errs: u64 = 0;
@@ -68,6 +69,11 @@ pub async fn run_reporter(cfg: ReporterConfig<'_>) {
         total_calls += s.ok + s.err;
         total_latency_sum_us += s.latency_sum_us;
         total_latency_samples += s.latency_samples;
+        total_errors.timeout += s.errors.timeout;
+        total_errors.not_delivered += s.errors.not_delivered;
+        total_errors.http_status += s.errors.http_status;
+        total_errors.transport += s.errors.transport;
+        total_errors.connection_drop += s.errors.connection_drop;
 
         let elapsed = start.elapsed().as_secs();
         let w_ops = s.ok + s.err;
@@ -148,8 +154,13 @@ pub async fn run_reporter(cfg: ReporterConfig<'_>) {
                 0.0
             };
             eprintln!(
-                "FINAL: players={} total_calls={} total_oks={} total_errs={} lat_avg_ms={:.2}",
-                players, total_calls, total_oks, total_errs, lat_avg_ms,
+                "FINAL: players={} total_calls={} total_oks={} total_errs={} lat_avg_ms={:.2} err_json={}",
+                players,
+                total_calls,
+                total_oks,
+                total_errs,
+                lat_avg_ms,
+                total_errors.to_json(),
             );
             if has_actions {
                 let duration_secs = start.elapsed().as_secs().max(1);


### PR DESCRIPTION
## Summary

Supports **[arcane-scaling-benchmarks](https://github.com/brainy-bots/arcane-scaling-benchmarks)** harness work: richer failure breakdown and reproducible worst-case load patterns.

## Changes

- **`ErrorKind` / `ErrorBreakdown`:** classify and aggregate errors; emit **`err_json`** on `FINAL:` alongside existing totals.
- **Backends:** map timeouts, HTTP errors, transport, `not_delivered`, `connection_drop` where applicable.
- **`burst.rs`:** deterministic periodic action burst + zone convergence; **default on**; config + CLI flags.
- **Reporter / spawn / player** wiring; **`cargo test -p arcane-swarm`** passes.

## Related

- Benchmark repo: [PR #10](https://github.com/brainy-bots/arcane-scaling-benchmarks/pull/10) (submodule bump + `Run-Benchmark.ps1` integration).

## Merge order

Merge this **before** or **with** the benchmark PR so the submodule SHA on `master` is consistent.