### PR TITLE
feat(swarm): send game actions through cluster WebSocket in Arcane mode

### DIFF
--- a/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
@@ -11,8 +11,8 @@ use tokio::time;
 use tokio_tungstenite::tungstenite::Message;
 
 use arcane_swarm::{
-    is_zone_event_active, player_state_json, ArcaneEndpoint, BurstConfig, ErrorKind, Metrics,
-    Player,
+    game_action_json, is_zone_event_active, player_state_json, ArcaneEndpoint, BurstConfig,
+    ErrorKind, Metrics, Player,
 };
 
 #[derive(serde::Deserialize)]
@@ -82,10 +82,42 @@ pub(crate) struct ArcanePlayerLoop {
     pub tick_interval: Duration,
     pub metrics: Arc<Metrics>,
     pub read_metrics: Arc<Metrics>,
+    pub action_metrics: Arc<Metrics>,
     pub stop: Arc<AtomicBool>,
     pub cluster_flag: Arc<AtomicBool>,
+    pub actions_per_sec: f64,
     pub burst: BurstConfig,
     pub run_started: std::time::Instant,
+}
+
+/// Pick a random game action for this player at this tick.
+fn random_arcane_action(player_idx: u32, tick: u64) -> (&'static str, String) {
+    let seed = (player_idx as u64).wrapping_mul(31) ^ tick.wrapping_mul(7);
+    match seed % 5 {
+        0 => {
+            let item_type = (seed % 20) as u32;
+            let quantity = 1 + (seed % 5) as u32;
+            (
+                "pickup_item",
+                format!(r#"{{"item_type":{},"quantity":{}}}"#, item_type, quantity),
+            )
+        }
+        1 => {
+            let item_type = (seed % 20) as u32;
+            ("use_item", format!(r#"{{"item_type":{}}}"#, item_type))
+        }
+        _ => {
+            let event_type = (seed % 4) as u32;
+            (
+                "interact",
+                format!(
+                    r#"{{"target_id":"{}","event_type":{}}}"#,
+                    uuid::Uuid::nil(),
+                    event_type
+                ),
+            )
+        }
+    }
 }
 
 pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
@@ -98,8 +130,10 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
         tick_interval,
         metrics,
         read_metrics,
+        action_metrics,
         stop,
         cluster_flag,
+        actions_per_sec,
         burst,
         run_started,
     } = ctx;
@@ -144,12 +178,23 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
     let mut interval = time::interval(tick_interval);
     interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
 
+    // Action timing: send game actions at configured rate via the same WebSocket
+    let action_interval_us = if actions_per_sec > 0.0 {
+        Some((1_000_000.0 / actions_per_sec) as u64)
+    } else {
+        None
+    };
+    let mut last_action = std::time::Instant::now();
+    let mut action_tick: u64 = 0;
+
     while !stop.load(Ordering::Relaxed) {
         interval.tick().await;
         if is_zone_event_active(run_started.elapsed().as_millis() as u64, burst) {
             player.steer_to_point(2500.0, 2500.0);
         }
         player.tick(tick_dt, cluster_flag.load(Ordering::Relaxed));
+
+        // Send movement
         let msg = player_state_json(
             &player.id, player.x, player.y, player.z, player.vx, player.vy, player.vz,
         );
@@ -164,6 +209,29 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
                     eprintln!("[player 0] ws send error: {}", e);
                 }
                 break;
+            }
+        }
+
+        // Send game action if it's time
+        if let Some(interval_us) = action_interval_us {
+            if last_action.elapsed() >= Duration::from_micros(interval_us) {
+                action_tick += 1;
+                let (action_type, payload) = random_arcane_action(idx, action_tick);
+                let action_msg = game_action_json(&player.id, action_type, &payload);
+                let t0 = std::time::Instant::now();
+                match sink.send(Message::Text(action_msg)).await {
+                    Ok(_) => {
+                        action_metrics.record_ok(t0.elapsed());
+                    }
+                    Err(e) => {
+                        action_metrics.record_err();
+                        if idx == 0 {
+                            eprintln!("[player 0] ws action send error: {}", e);
+                        }
+                        break;
+                    }
+                }
+                last_action = std::time::Instant::now();
             }
         }
     }

--- a/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
@@ -116,6 +116,8 @@ impl BackendRuntime for SpacetimeRuntime {
 
 struct ArcaneRuntime {
     endpoint: ArcaneEndpoint,
+    action_metrics: Arc<Metrics>,
+    actions_per_sec: f64,
 }
 
 impl BackendRuntime for ArcaneRuntime {
@@ -138,8 +140,10 @@ impl BackendRuntime for ArcaneRuntime {
                 tick_interval: params.tick_interval,
                 metrics: shared.metrics.clone(),
                 read_metrics: shared.read_metrics.clone(),
+                action_metrics: self.action_metrics.clone(),
                 stop: params.stop,
                 cluster_flag: shared.cluster_flag.clone(),
+                actions_per_sec: self.actions_per_sec,
                 burst: shared.burst,
                 run_started: shared.run_started,
             },
@@ -161,6 +165,11 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
     let stdb_base = cfg.spacetimedb_uri.trim_end_matches('/').to_string();
     let base = format!("{}/v1/database/{}/call", stdb_base, cfg.database);
     let sql_url = format!("{}/v1/database/{}/sql", stdb_base, cfg.database);
+
+    let metrics = Arc::new(Metrics::new());
+    let action_metrics = Arc::new(Metrics::new());
+    let read_metrics = Arc::new(Metrics::new());
+
     let backend_runtime: Arc<dyn BackendRuntime> = match cfg.backend {
         Backend::SpacetimeDb => Arc::new(SpacetimeRuntime {
             url_update_player: format!("{}/update_player", base),
@@ -176,7 +185,7 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
                 },
                 None => ArcaneEndpoint::SingleUrl(cfg.arcane_ws.clone()),
             };
-            Arc::new(ArcaneRuntime { endpoint })
+            Arc::new(ArcaneRuntime { endpoint, action_metrics: action_metrics.clone(), actions_per_sec: cfg.actions_per_sec })
         }
     };
     let backend_name = backend_runtime.name();
@@ -197,10 +206,6 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
     let desired_players = Arc::new(AtomicU32::new(cfg.players.min(cfg.max_players)));
     let total_players_atomic = desired_players.clone();
     let stop_all = Arc::new(AtomicBool::new(false));
-
-    let metrics = Arc::new(Metrics::new());
-    let action_metrics = Arc::new(Metrics::new());
-    let read_metrics = Arc::new(Metrics::new());
 
     let max_players = cfg.max_players;
     // 0..max => player tasks, max..2*max => action tasks
@@ -450,6 +455,11 @@ async fn main() {
     let stdb_base = cfg.spacetimedb_uri.trim_end_matches('/').to_string();
     let base = format!("{}/v1/database/{}/call", stdb_base, cfg.database);
     let sql_url = format!("{}/v1/database/{}/sql", stdb_base, cfg.database);
+
+    let metrics = Arc::new(Metrics::new());
+    let action_metrics = Arc::new(Metrics::new());
+    let read_metrics = Arc::new(Metrics::new());
+
     let backend_runtime: Arc<dyn BackendRuntime> = match cfg.backend {
         Backend::SpacetimeDb => Arc::new(SpacetimeRuntime {
             url_update_player: format!("{}/update_player", base),
@@ -465,7 +475,7 @@ async fn main() {
                 },
                 None => ArcaneEndpoint::SingleUrl(cfg.arcane_ws.clone()),
             };
-            Arc::new(ArcaneRuntime { endpoint })
+            Arc::new(ArcaneRuntime { endpoint, action_metrics: action_metrics.clone(), actions_per_sec: cfg.actions_per_sec })
         }
     };
     let backend_name = backend_runtime.name();
@@ -492,9 +502,6 @@ async fn main() {
         );
     }
 
-    let metrics = Arc::new(Metrics::new());
-    let action_metrics = Arc::new(Metrics::new());
-    let read_metrics = Arc::new(Metrics::new());
     let stop = Arc::new(AtomicBool::new(false));
     let total_players_atomic = Arc::new(AtomicU32::new(cfg.players));
     let mut handles = Vec::with_capacity(cfg.players as usize * 3);
@@ -558,7 +565,9 @@ async fn main() {
         let _ = backend_runtime.spawn_read(&loop_shared, &params, cfg.read_rate);
     }
 
-    if cfg.actions_per_sec > 0.0 {
+    // In Arcane mode, actions go through the WebSocket (handled inside player_loop_arcane).
+    // In SpacetimeDB mode, actions go via HTTP to SpacetimeDB directly.
+    if cfg.actions_per_sec > 0.0 && backend_name == "spacetimedb" {
         for i in 0..cfg.players {
             let player_id = all_ids[i as usize];
             handles.push(tokio::spawn(backends_spacetimedb::action_loop(

--- a/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
@@ -185,7 +185,11 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
                 },
                 None => ArcaneEndpoint::SingleUrl(cfg.arcane_ws.clone()),
             };
-            Arc::new(ArcaneRuntime { endpoint, action_metrics: action_metrics.clone(), actions_per_sec: cfg.actions_per_sec })
+            Arc::new(ArcaneRuntime {
+                endpoint,
+                action_metrics: action_metrics.clone(),
+                actions_per_sec: cfg.actions_per_sec,
+            })
         }
     };
     let backend_name = backend_runtime.name();
@@ -475,7 +479,11 @@ async fn main() {
                 },
                 None => ArcaneEndpoint::SingleUrl(cfg.arcane_ws.clone()),
             };
-            Arc::new(ArcaneRuntime { endpoint, action_metrics: action_metrics.clone(), actions_per_sec: cfg.actions_per_sec })
+            Arc::new(ArcaneRuntime {
+                endpoint,
+                action_metrics: action_metrics.clone(),
+                actions_per_sec: cfg.actions_per_sec,
+            })
         }
     };
     let backend_name = backend_runtime.name();

--- a/crates/arcane-swarm/src/lib.rs
+++ b/crates/arcane-swarm/src/lib.rs
@@ -28,5 +28,5 @@ pub use config::{parse_args, ArcaneEndpoint, Backend, Config, SwarmMode};
 pub use engine_api::{EngineRunConfig, EngineRunHandle, EngineSummary, SwarmEngine};
 pub use metrics::{ErrorBreakdown, ErrorKind, Metrics, MetricsSnapshot};
 pub use player::Player;
-pub use protocol::{player_state_json, VISIBILITY_RADIUS};
+pub use protocol::{game_action_json, player_state_json, VISIBILITY_RADIUS};
 pub use reporter::{fmt_bytes, run_reporter, ReporterConfig};

--- a/crates/arcane-swarm/src/metrics.rs
+++ b/crates/arcane-swarm/src/metrics.rs
@@ -157,7 +157,7 @@ impl Metrics {
         let sum = self.latency_sum_us.swap(0, Ordering::Relaxed);
         let max = self.latency_max_us.swap(0, Ordering::Relaxed);
         let n = self.latency_samples.swap(0, Ordering::Relaxed);
-        let avg = if n > 0 { sum / n } else { 0 };
+        let avg = sum.checked_div(n).unwrap_or(0);
         let bytes = self.bytes.swap(0, Ordering::Relaxed);
         let errors = ErrorBreakdown {
             timeout: self.err_timeout.swap(0, Ordering::Relaxed),

--- a/crates/arcane-swarm/src/protocol.rs
+++ b/crates/arcane-swarm/src/protocol.rs
@@ -20,3 +20,16 @@ pub fn player_state_json(
         id, x, y, z, vx, vy, vz
     )
 }
+
+/// JSON for Arcane cluster `GAME_ACTION` WebSocket messages.
+/// Used when simulation-affecting actions go through the cluster.
+pub fn game_action_json(
+    entity_id: &uuid::Uuid,
+    action_type: &str,
+    payload: &str,
+) -> String {
+    format!(
+        r#"{{"type":"GAME_ACTION","entity_id":"{}","action_type":"{}","payload":{}}}"#,
+        entity_id, action_type, payload
+    )
+}

--- a/crates/arcane-swarm/src/protocol.rs
+++ b/crates/arcane-swarm/src/protocol.rs
@@ -23,11 +23,7 @@ pub fn player_state_json(
 
 /// JSON for Arcane cluster `GAME_ACTION` WebSocket messages.
 /// Used when simulation-affecting actions go through the cluster.
-pub fn game_action_json(
-    entity_id: &uuid::Uuid,
-    action_type: &str,
-    payload: &str,
-) -> String {
+pub fn game_action_json(entity_id: &uuid::Uuid, action_type: &str, payload: &str) -> String {
     format!(
         r#"{{"type":"GAME_ACTION","entity_id":"{}","action_type":"{}","payload":{}}}"#,
         entity_id, action_type, payload


### PR DESCRIPTION
## Summary

In Arcane mode, simulation-affecting game actions are now sent through the cluster WebSocket as GAME_ACTION messages instead of direct HTTP calls to SpacetimeDB.

### Changes
- protocol.rs: new game_action_json() helper
- backends_arcane.rs: player loop sends actions via WebSocket at configured rate
- main.rs: ArcaneRuntime carries action_metrics; SpacetimeDB action_loop skipped for Arcane backend

### Test plan
- [x] All 10 existing tests pass
- [x] Builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)