### PR TITLE
feat(arcane): switch WS protocol from JSON to binary via arcane-wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,7 @@ dependencies = [
 name = "arcane-swarm"
 version = "0.1.0"
 dependencies = [
+ "arcane-wire",
  "futures-util",
  "reqwest",
  "serde",
@@ -85,6 +86,16 @@ dependencies = [
  "spacetimedb-sdk",
  "tokio",
  "tokio-tungstenite 0.21.0",
+ "uuid",
+]
+
+[[package]]
+name = "arcane-wire"
+version = "0.1.0"
+source = "git+https://github.com/brainy-bots/arcane.git?branch=main#5aa2ab4fb5e8fb966e90264b75068605fd378bb7"
+dependencies = [
+ "postcard",
+ "serde",
  "uuid",
 ]
 
@@ -99,6 +110,15 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -246,6 +266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +348,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -469,6 +504,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -760,6 +807,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +840,20 @@ dependencies = [
  "rayon",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1403,6 +1473,19 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2230,6 +2313,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "sqlparser"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,6 +2845,7 @@ checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/crates/arcane-swarm/Cargo.toml
+++ b/crates/arcane-swarm/Cargo.toml
@@ -17,6 +17,11 @@ uuid = { version = "1", features = ["v4"] }
 # stays in sync. Bindings live in src/bin/arcane_swarm/spacetimedb_bindings/ and are
 # produced by `spacetime generate --lang rust --module-path <full module>`.
 spacetimedb-sdk = "2.1"
+# Shared wire schema with the cluster (arcane repo). Pinned to main so
+# the benchmark tracks the latest protocol; the benchmark workspace pins
+# both arcane and arcane_swarm as submodules, so this resolves to the
+# same commit in the benchmark CI.
+arcane-wire = { git = "https://github.com/brainy-bots/arcane.git", branch = "main" }
 
 [[bin]]
 name = "arcane-swarm"

--- a/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
@@ -11,7 +11,7 @@ use tokio::time;
 use tokio_tungstenite::tungstenite::Message;
 
 use arcane_swarm::{
-    game_action_json, is_zone_event_active, player_state_json, ArcaneEndpoint, BurstConfig,
+    encode_game_action, encode_player_state, is_zone_event_active, ArcaneEndpoint, BurstConfig,
     ErrorKind, Metrics, Player,
 };
 
@@ -194,12 +194,13 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
         }
         player.tick(tick_dt, cluster_flag.load(Ordering::Relaxed));
 
-        // Send movement
-        let msg = player_state_json(
+        // Send movement — binary postcard frame for fairness with SpacetimeDB's
+        // BSATN. See brainy-bots/arcane#28 for motivation.
+        let msg = encode_player_state(
             &player.id, player.x, player.y, player.z, player.vx, player.vy, player.vz,
         );
         let t0 = std::time::Instant::now();
-        match sink.send(Message::Text(msg)).await {
+        match sink.send(Message::Binary(msg)).await {
             Ok(_) => {
                 metrics.record_ok(t0.elapsed());
             }
@@ -212,14 +213,16 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
             }
         }
 
-        // Send game action if it's time
+        // Send game action if it's time. Action payload is already a JSON
+        // string (from random_arcane_action); we pass its bytes through
+        // opaquely — the cluster deserializes on the other side.
         if let Some(interval_us) = action_interval_us {
             if last_action.elapsed() >= Duration::from_micros(interval_us) {
                 action_tick += 1;
                 let (action_type, payload) = random_arcane_action(idx, action_tick);
-                let action_msg = game_action_json(&player.id, action_type, &payload);
+                let action_msg = encode_game_action(&player.id, action_type, payload.as_bytes());
                 let t0 = std::time::Instant::now();
-                match sink.send(Message::Text(action_msg)).await {
+                match sink.send(Message::Binary(action_msg)).await {
                     Ok(_) => {
                         action_metrics.record_ok(t0.elapsed());
                     }

--- a/crates/arcane-swarm/src/lib.rs
+++ b/crates/arcane-swarm/src/lib.rs
@@ -28,5 +28,5 @@ pub use config::{parse_args, ArcaneEndpoint, Backend, Config, SwarmMode};
 pub use engine_api::{EngineRunConfig, EngineRunHandle, EngineSummary, SwarmEngine};
 pub use metrics::{ErrorBreakdown, ErrorKind, Metrics, MetricsSnapshot};
 pub use player::Player;
-pub use protocol::{game_action_json, player_state_json, VISIBILITY_RADIUS};
+pub use protocol::{encode_game_action, encode_player_state, VISIBILITY_RADIUS};
 pub use reporter::{fmt_bytes, run_reporter, ReporterConfig};

--- a/crates/arcane-swarm/src/protocol.rs
+++ b/crates/arcane-swarm/src/protocol.rs
@@ -1,12 +1,23 @@
 //! Wire-format helpers shared by backends (e.g. Arcane WebSocket payloads).
 //!
-//! Keeps shared payload fragments in one place to avoid backend drift.
+//! The Arcane wire protocol uses postcard-encoded binary frames from
+//! [`arcane_wire`]. This module exposes small helpers that build the
+//! binary frame bytes from the values a backend loop already has on hand,
+//! so backend code doesn't need to know about the wire schema.
+//!
+//! Binary (not JSON) for benchmark fairness with SpacetimeDB's BSATN
+//! default — see brainy-bots/arcane#28 for the motivation + microbench.
+
+use arcane_wire::{
+    encode_client, ClientFrame, GameActionPayload, PlayerStatePayload, Vec3 as WireVec3,
+};
 
 /// Spatial query radius (server units) for SpacetimeDB read simulation.
 pub const VISIBILITY_RADIUS: f64 = 1500.0;
 
-/// JSON for Arcane cluster `PLAYER_STATE` WebSocket messages.
-pub fn player_state_json(
+/// Encode one `PLAYER_STATE` frame as postcard bytes for the Arcane cluster
+/// WebSocket. Returned bytes are ready to send as `Message::Binary`.
+pub fn encode_player_state(
     id: &uuid::Uuid,
     x: f64,
     y: f64,
@@ -14,18 +25,61 @@ pub fn player_state_json(
     vx: f64,
     vy: f64,
     vz: f64,
-) -> String {
-    format!(
-        r#"{{"type":"PLAYER_STATE","entity_id":"{}","position":{{"x":{},"y":{},"z":{}}},"velocity":{{"x":{},"y":{},"z":{}}}}}"#,
-        id, x, y, z, vx, vy, vz
-    )
+) -> Vec<u8> {
+    let frame = ClientFrame::PlayerState(PlayerStatePayload {
+        entity_id: *id,
+        position: WireVec3::new(x, y, z),
+        velocity: WireVec3::new(vx, vy, vz),
+        user_data: Vec::new(),
+    });
+    // encode_client returns Err only on allocator failure or serialize-bug;
+    // both are fatal rather than recoverable for a benchmark client — unwrap
+    // so any such bug fails loudly instead of silently dropping messages.
+    encode_client(&frame).expect("postcard encode of ClientFrame::PlayerState cannot fail")
 }
 
-/// JSON for Arcane cluster `GAME_ACTION` WebSocket messages.
-/// Used when simulation-affecting actions go through the cluster.
-pub fn game_action_json(entity_id: &uuid::Uuid, action_type: &str, payload: &str) -> String {
-    format!(
-        r#"{{"type":"GAME_ACTION","entity_id":"{}","action_type":"{}","payload":{}}}"#,
-        entity_id, action_type, payload
-    )
+/// Encode one `GAME_ACTION` frame as postcard bytes for the Arcane cluster
+/// WebSocket. `payload` is treated as opaque application bytes (typically
+/// the caller passes in JSON bytes).
+pub fn encode_game_action(entity_id: &uuid::Uuid, action_type: &str, payload: &[u8]) -> Vec<u8> {
+    let frame = ClientFrame::Action(GameActionPayload {
+        entity_id: *entity_id,
+        action_type: action_type.to_string(),
+        payload: payload.to_vec(),
+    });
+    encode_client(&frame).expect("postcard encode of ClientFrame::Action cannot fail")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arcane_wire::decode_client;
+
+    #[test]
+    fn encode_player_state_roundtrips() {
+        let id = uuid::Uuid::from_u128(0x1111_2222);
+        let bytes = encode_player_state(&id, 1.25, 2.5, 3.75, 0.1, 0.0, -0.1);
+        let decoded = decode_client(&bytes).unwrap();
+        let ClientFrame::PlayerState(payload) = decoded else {
+            panic!("expected PlayerState variant");
+        };
+        assert_eq!(payload.entity_id, id);
+        assert_eq!(payload.position.x, 1.25);
+        assert_eq!(payload.velocity.z, -0.1);
+        assert!(payload.user_data.is_empty());
+    }
+
+    #[test]
+    fn encode_game_action_roundtrips_with_payload() {
+        let id = uuid::Uuid::from_u128(7);
+        let json = br#"{"item_type":5}"#;
+        let bytes = encode_game_action(&id, "use_item", json);
+        let decoded = decode_client(&bytes).unwrap();
+        let ClientFrame::Action(payload) = decoded else {
+            panic!("expected Action variant");
+        };
+        assert_eq!(payload.entity_id, id);
+        assert_eq!(payload.action_type, "use_item");
+        assert_eq!(payload.payload, json);
+    }
 }


### PR DESCRIPTION
## Summary

Swarm-side half of the Arcane binary wire protocol change (task #34). Pairs with brainy-bots/arcane PR #30.

- \`protocol.rs\`: replaces \`player_state_json\` / \`game_action_json\` with \`encode_player_state\` / \`encode_game_action\` returning postcard bytes from the shared \`arcane-wire\` schema.
- \`backends_arcane.rs\`: sends \`Message::Binary\` for both movement and actions.
- \`Cargo.toml\`: new git dep on \`arcane-wire\` tracking arcane main.

## Why

Arcane's current WS protocol is JSON text. SpacetimeDB's SDK uses BSATN binary by default. Benchmarking JSON Arcane vs binary SpacetimeDB handicaps Arcane in the published numbers. Microbench on a typical PLAYER_STATE payload:
- JSON: 281 ns/op, 150 bytes.
- postcard: 82 ns/op, 64 bytes.
- 3.4x encode, 2.3x size. Real scaling win is on cluster broadcast fanout where the size reduction compounds per connected client.

## Deployment

Forward-compatible with the cluster PR (brainy-bots/arcane#30). Per-connection format preference on the cluster side means:
- Swarm sends Message::Binary (this PR) → cluster decodes binary → cluster broadcasts binary to swarm.
- Existing JSON clients (UE5 adapter, etc.) keep working — cluster continues to accept Message::Text and respond in kind.

## Test plan

- [x] \`cargo check\` — clean, resolves arcane-wire from git.
- [x] \`cargo clippy --tests -- -D warnings\` — clean.
- [x] \`cargo test\` — 13 passes, including two new protocol roundtrip tests (\`encode_player_state_roundtrips\`, \`encode_game_action_roundtrips_with_payload\`) that verify what bytes the cluster will receive.
- [x] \`cargo fmt --check\` — clean.
- [ ] End-to-end against running cluster (requires brainy-bots/arcane PR #30 to be merged and a fresh cluster build).

## Follow-ups

- Benchmark repo submodule bumps once both arcane and arcane_swarm main branches have these landed.

Refs brainy-bots/arcane#28. Needs brainy-bots/arcane#30 merged first for the cluster to actually decode these frames.