### PR TITLE
fix(swarm): emit driver CPU/RSS telemetry in control mode

### DIFF
--- a/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
@@ -23,8 +23,8 @@ use std::time::Duration;
 use tokio::time;
 
 use arcane_swarm::{
-    parse_args, run_reporter, ArcaneEndpoint, Backend, Config, Metrics, ReporterConfig, SwarmMode,
-    VISIBILITY_RADIUS,
+    parse_args, run_reporter, sample_proc, ArcaneEndpoint, Backend, Config, Metrics,
+    ReporterConfig, SwarmMode, VISIBILITY_RADIUS,
 };
 
 mod backends_arcane;
@@ -217,6 +217,48 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
     let desired_players = Arc::new(AtomicU32::new(cfg.players.min(cfg.max_players)));
     let total_players_atomic = desired_players.clone();
     let stop_all = Arc::new(AtomicBool::new(false));
+
+    // Driver CPU/RSS sampler. Runs for the full lifetime of control mode so it
+    // covers the ramp window (can exceed the measurement window by minutes at
+    // high player counts). Without this, ramp-timeout tiers produce no driver
+    // telemetry — the reporter that `run_reporter` owns is not spawned in
+    // control mode, since control mode reports are driven by REPORT commands.
+    // Emitted line shape is kept identical to the reporter's driver fields so
+    // any post-mortem tooling can parse both uniformly.
+    {
+        let stop_all = stop_all.clone();
+        let total_players_atomic = total_players_atomic.clone();
+        tokio::spawn(async move {
+            let mut interval = time::interval(Duration::from_secs(1));
+            interval.tick().await;
+            let mut prev_cpu_ticks: Option<u64> = None;
+            loop {
+                interval.tick().await;
+                if stop_all.load(Ordering::Relaxed) {
+                    break;
+                }
+                let (drv_cpu_pct, drv_rss_mb) = match sample_proc() {
+                    Some((cpu_ticks, rss_kb)) => {
+                        let cpu_pct = match prev_cpu_ticks {
+                            Some(prev) => cpu_ticks.saturating_sub(prev) as f64,
+                            None => 0.0,
+                        };
+                        prev_cpu_ticks = Some(cpu_ticks);
+                        (Some(cpu_pct), Some(rss_kb as f64 / 1024.0))
+                    }
+                    None => (None, None),
+                };
+                if let (Some(cpu), Some(rss)) = (drv_cpu_pct, drv_rss_mb) {
+                    let elapsed = run_started.elapsed().as_secs();
+                    let players = total_players_atomic.load(Ordering::Relaxed);
+                    eprintln!(
+                        "[{:>4}s] [driver] players={} drv_cpu={:.1}% drv_rss={:.0}MB",
+                        elapsed, players, cpu, rss,
+                    );
+                }
+            }
+        });
+    }
 
     let max_players = cfg.max_players;
     // One task slot per simulated player — the player loop carries both

--- a/crates/arcane-swarm/src/lib.rs
+++ b/crates/arcane-swarm/src/lib.rs
@@ -29,4 +29,4 @@ pub use engine_api::{EngineRunConfig, EngineRunHandle, EngineSummary, SwarmEngin
 pub use metrics::{ErrorBreakdown, ErrorKind, Metrics, MetricsSnapshot};
 pub use player::Player;
 pub use protocol::{encode_game_action, encode_player_state, VISIBILITY_RADIUS};
-pub use reporter::{fmt_bytes, run_reporter, ReporterConfig};
+pub use reporter::{fmt_bytes, run_reporter, sample_proc, ReporterConfig};

--- a/crates/arcane-swarm/src/reporter.rs
+++ b/crates/arcane-swarm/src/reporter.rs
@@ -19,7 +19,7 @@ use crate::metrics::{ErrorBreakdown, Metrics, MetricsSnapshot};
 ///
 /// `rss_kb` is `VmRSS` from `/proc/self/status` (resident memory in kB).
 #[cfg(target_os = "linux")]
-fn sample_proc() -> Option<(u64, u64)> {
+pub fn sample_proc() -> Option<(u64, u64)> {
     let stat = std::fs::read_to_string("/proc/self/stat").ok()?;
     // `comm` (field 2) may contain spaces and parens — split after the final ')'.
     let after = stat.rfind(')').map(|i| &stat[i + 1..])?;
@@ -40,7 +40,7 @@ fn sample_proc() -> Option<(u64, u64)> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn sample_proc() -> Option<(u64, u64)> {
+pub fn sample_proc() -> Option<(u64, u64)> {
     None
 }
 


### PR DESCRIPTION
## Summary
- Control-mode swarms (the path the benchmark harness drives via \`--control-port\`) returned from \`run_control_mode\` before \`run_reporter\` was ever spawned, so the driver CPU/RSS lines added in #7 never appeared in real benchmark stderr.
- Confirmed in run \`20260421_052026\`: \`arcane_2_9402_stderr.log\` contains only the 4 \`FINAL:\` lines plus the listen banner — zero per-second driver lines across the entire 6-minute sweep.
- Spawn a 1 Hz driver sampler at the top of \`run_control_mode\`, using the now-public \`sample_proc()\` helper from \`reporter\`. Runs for the full control-mode lifetime, so ramp-timeout tiers (which never reach REPORT) also get driver attribution.

## Test plan
- [x] \`cargo check -p arcane-swarm --bin arcane-swarm\`
- [x] \`cargo clippy -p arcane-swarm --bin arcane-swarm --all-targets -- -D warnings\`
- [x] \`cargo test -p arcane-swarm --lib\` — 10 passed
- [x] Local smoke test: run with \`--control-port\`, confirm per-second \`[ Ns] [driver] players=N drv_cpu=X% drv_rss=YMB\` lines appear on stderr
- [ ] Next AWS rerun: verify the per-tier swarm stderr log now contains \`[driver]\` lines across the ramp window

🤖 Generated with [Claude Code](https://claude.com/claude-code)