### PR TITLE
feat(swarm): measure client-perceived latency across both backends

### DIFF
--- a/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
@@ -1,11 +1,32 @@
 //! Arcane backend loops (manager join + cluster WebSocket write/read).
 //!
 //! Implements binary-internal runtime behavior for `--backend arcane`.
+//!
+//! ## What the "lat" column means here
+//!
+//! The client's outbound writes are fire-and-forget WebSocket frames —
+//! `sink.send(Message::Binary(_))` returns in nanoseconds once the bytes are
+//! queued in the local send buffer, regardless of whether the cluster is
+//! healthy, lagging, or dead. Timing the call site is therefore meaningless.
+//!
+//! Instead the swarm measures **client-perceived latency**: the wall-clock
+//! gap between "I wrote state at T0" and "the cluster's next broadcast frame
+//! carrying my own entity landed in my receive buffer at T1". That's what a
+//! real game client experiences — action → world-reflection. Under server
+//! load the cluster's tick slides later, the broadcast arrives late, and the
+//! number rises. Under catastrophic load the broadcast stops, and the
+//! `NotDelivered` / `ConnectionDrop` counters pick up.
+//!
+//! The swarm decodes each incoming binary frame via
+//! [`arcane_wire::decode_server`] and walks `DeltaPayload::updated`; when it
+//! finds its own `entity_id` it computes `now - last_send` and records the
+//! sample. Every outbound write (movement or action) updates `last_send`.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use arcane_wire::{decode_server, ServerFrame};
 use futures_util::{SinkExt, StreamExt};
 use tokio::time;
 use tokio_tungstenite::tungstenite::Message;
@@ -155,16 +176,43 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
     };
     let (mut sink, mut stream) = ws_stream.split();
 
+    // Shared micros-since-run-start of the player's most recent outbound write
+    // (movement or action). The drain task reads this when it spots the
+    // player's own entity_id in an incoming broadcast frame and computes
+    // latency = now - last_send. Using a shared atomic rather than passing
+    // through a channel keeps the hot paths lock-free.
+    let last_send_micros = Arc::new(AtomicI64::new(-1));
+
     let stop_drain = stop.clone();
     let rm = read_metrics.clone();
+    let latency_metrics = metrics.clone();
+    let last_send_drain = last_send_micros.clone();
+    let my_id = player.id;
+    let drain_run_started = run_started;
     tokio::spawn(async move {
         while !stop_drain.load(Ordering::Relaxed) {
             match stream.next().await {
-                Some(Ok(Message::Text(txt))) => {
-                    rm.record_inbound_ok(txt.len() as u64);
-                }
                 Some(Ok(Message::Binary(bin))) => {
                     rm.record_inbound_ok(bin.len() as u64);
+                    // Decode the cluster's broadcast delta and look for our
+                    // own entity_id. The first hit produces a real latency
+                    // sample; extra hits in the same frame (shouldn't happen,
+                    // but defensive) are ignored to avoid double-counting.
+                    if let Ok(ServerFrame::Delta(payload)) = decode_server(&bin) {
+                        if payload.updated.iter().any(|e| e.entity_id == my_id) {
+                            let sent = last_send_drain.load(Ordering::Relaxed);
+                            if sent >= 0 {
+                                let now = drain_run_started.elapsed().as_micros() as i64;
+                                let lat_us = (now - sent).max(0) as u64;
+                                latency_metrics.record_ok(Duration::from_micros(lat_us));
+                            }
+                        }
+                    }
+                }
+                Some(Ok(Message::Text(txt))) => {
+                    // Cluster no longer speaks text frames after Shape B, but
+                    // we still accept any bytes we receive as inbound traffic.
+                    rm.record_inbound_ok(txt.len() as u64);
                 }
                 Some(Ok(_)) => {}
                 _ => {
@@ -199,10 +247,12 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
         let msg = encode_player_state(
             &player.id, player.x, player.y, player.z, player.vx, player.vy, player.vz,
         );
-        let t0 = std::time::Instant::now();
         match sink.send(Message::Binary(msg)).await {
             Ok(_) => {
-                metrics.record_ok(t0.elapsed());
+                // Count the successful enqueue; latency is recorded by the
+                // drain task when it sees the cluster echo this write back.
+                metrics.record_ok_count();
+                last_send_micros.store(run_started.elapsed().as_micros() as i64, Ordering::Relaxed);
             }
             Err(e) => {
                 metrics.record_err_kind(ErrorKind::NotDelivered);
@@ -221,10 +271,14 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
                 action_tick += 1;
                 let (action_type, payload) = random_arcane_action(idx, action_tick);
                 let action_msg = encode_game_action(&player.id, action_type, payload.as_bytes());
-                let t0 = std::time::Instant::now();
                 match sink.send(Message::Binary(action_msg)).await {
                     Ok(_) => {
-                        action_metrics.record_ok(t0.elapsed());
+                        // Same pattern as movement: count the enqueue; the
+                        // next echo carrying our entity provides the latency
+                        // sample for the combined write stream.
+                        action_metrics.record_ok_count();
+                        last_send_micros
+                            .store(run_started.elapsed().as_micros() as i64, Ordering::Relaxed);
                     }
                     Err(e) => {
                         action_metrics.record_err();

--- a/crates/arcane-swarm/src/bin/arcane_swarm/backends_spacetimedb.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/backends_spacetimedb.rs
@@ -32,12 +32,32 @@
 //! uses one WS per player, so the extra sockets were pure benchmark-fairness
 //! noise. This revision collapses them back to one.
 //!
-//! ## What still uses HTTP
+//! ## What the "lat" column means here
 //!
-//! Spatial reads (`SELECT * FROM entity WHERE x BETWEEN … AND z BETWEEN …`)
-//! stay on the HTTP SQL endpoint. After the module-side `btree(x, z)` index
-//! landed, these are cheap — SQL subscriptions would be equivalent here for a
-//! worse-DX tradeoff, so the HTTP path survives.
+//! The SDK's `conn.reducers.update_player_input(...)` is fire-and-forget —
+//! the call returns in microseconds once the message is queued in the SDK's
+//! send buffer, regardless of whether SpacetimeDB has processed it. Timing
+//! the call site would always read ~0 ms and tell us nothing about server
+//! load. Instead the swarm measures **client-perceived latency**:
+//!
+//! 1. Every outbound write updates a shared `last_send_micros` for this
+//!    player.
+//! 2. The same connection is subscribed to the `entity` table (restricted to
+//!    a spatial region around the player's starting position, matching what
+//!    a real game client's area-of-interest subscription would look like).
+//! 3. When the SDK fires `on_update(Entity)` for the player's own entity_id,
+//!    we compute `now - last_send` and record that as a latency sample.
+//!
+//! That number represents "time from my action to seeing my world reflect
+//! it" — the same quantity a real game client experiences. Under server
+//! load, tick processing slides later, the subscription push lags, and the
+//! number rises. Under catastrophic load the subscription stalls and the
+//! `NotDelivered` / `Transport` error counters pick up.
+//!
+//! The previous HTTP SQL polling path (`reqwest::Client.post(sql_url)`
+//! against `/v1/database/<db>/sql`) has been removed — it was the CLI-shape
+//! read, not the pipe a game client uses. Subscriptions fill the same role
+//! and are what SpacetimeDB's docs recommend for real clients.
 
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, Ordering};
 use std::sync::Arc;
@@ -51,13 +71,13 @@ use arcane_swarm::{
 };
 
 use crate::spacetimedb_bindings::{
-    pickup_item_reducer::pickup_item, player_interact_reducer::player_interact,
-    remove_player_by_id_reducer::remove_player_by_id,
+    entity_table::EntityTableAccess, pickup_item_reducer::pickup_item,
+    player_interact_reducer::player_interact, remove_player_by_id_reducer::remove_player_by_id,
     update_player_input_reducer::update_player_input, update_player_reducer::update_player,
     use_item_reducer::use_item, DbConnection, Entity,
 };
 
-use spacetimedb_sdk::{DbContext, Uuid as StdbUuid};
+use spacetimedb_sdk::{DbContext, TableWithPrimaryKey, Uuid as StdbUuid};
 
 /// Convert a runtime `uuid::Uuid` into the SpacetimeDB-native `Uuid`. These
 /// are two different types (SpacetimeDB's is `{ __uuid__: u128 }`) even though
@@ -137,105 +157,6 @@ fn random_action(player_idx: u32, total_players: u32, tick: u64) -> GameAction {
     }
 }
 
-pub(crate) struct SharedPositions {
-    xs: Vec<AtomicI64>,
-    zs: Vec<AtomicI64>,
-}
-
-impl SharedPositions {
-    pub(crate) fn new(count: u32) -> Self {
-        let n = count as usize;
-        Self {
-            xs: (0..n).map(|_| AtomicI64::new(0)).collect(),
-            zs: (0..n).map(|_| AtomicI64::new(0)).collect(),
-        }
-    }
-
-    pub(crate) fn set(&self, idx: u32, x: f64, z: f64) {
-        let i = idx as usize;
-        self.xs[i].store(x as i64, Ordering::Relaxed);
-        self.zs[i].store(z as i64, Ordering::Relaxed);
-    }
-
-    pub(crate) fn get(&self, idx: u32) -> (f64, f64) {
-        let i = idx as usize;
-        (
-            self.xs[i].load(Ordering::Relaxed) as f64,
-            self.zs[i].load(Ordering::Relaxed) as f64,
-        )
-    }
-}
-
-pub(crate) struct SpacetimeReadLoop {
-    pub client: reqwest::Client,
-    pub sql_url: String,
-    pub read_rate: f64,
-    pub read_metrics: Arc<Metrics>,
-    pub stop: Arc<AtomicBool>,
-    pub player_idx: u32,
-    pub positions: Arc<SharedPositions>,
-}
-
-pub(crate) async fn read_loop_spacetimedb(ctx: SpacetimeReadLoop) {
-    let SpacetimeReadLoop {
-        client,
-        sql_url,
-        read_rate,
-        read_metrics,
-        stop,
-        player_idx,
-        positions,
-    } = ctx;
-
-    if read_rate <= 0.0 {
-        return;
-    }
-    let interval_us = (1_000_000.0 / read_rate) as u64;
-    let mut interval = time::interval(Duration::from_micros(interval_us));
-    interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
-
-    while !stop.load(Ordering::Relaxed) {
-        interval.tick().await;
-        let (px, pz) = positions.get(player_idx);
-        let query = format!(
-            "SELECT * FROM entity WHERE x >= {} AND x <= {} AND z >= {} AND z <= {}",
-            (px - VISIBILITY_RADIUS) as i64,
-            (px + VISIBILITY_RADIUS) as i64,
-            (pz - VISIBILITY_RADIUS) as i64,
-            (pz + VISIBILITY_RADIUS) as i64,
-        );
-        let t0 = Instant::now();
-        match client
-            .post(&sql_url)
-            .header("Content-Type", "text/plain")
-            .body(query)
-            .send()
-            .await
-        {
-            Ok(resp) if resp.status().is_success() => {
-                let bytes = resp.bytes().await.map(|b| b.len() as u64).unwrap_or(0);
-                read_metrics.record_ok_bytes(t0.elapsed(), bytes);
-            }
-            Ok(resp) => {
-                read_metrics.record_err_kind(ErrorKind::HttpStatus);
-                if player_idx == 0 {
-                    let s = resp.status();
-                    let t = resp.text().await.unwrap_or_default();
-                    eprintln!("[player 0 read] HTTP {}: {}", s, &t[..t.len().min(200)]);
-                }
-            }
-            Err(e) => {
-                let kind = if e.is_timeout() {
-                    ErrorKind::Timeout
-                } else {
-                    ErrorKind::Transport
-                };
-                read_metrics.record_err_kind(kind);
-            }
-        }
-    }
-}
-
 pub(crate) struct SpacetimePlayerLoop {
     /// One dedicated WebSocket per simulated player — shared between movement
     /// and action reducer calls. Opened inside `player_loop_spacetimedb` so
@@ -246,11 +167,11 @@ pub(crate) struct SpacetimePlayerLoop {
     pub total: u32,
     pub tick_interval: Duration,
     pub metrics: Arc<Metrics>,
+    pub read_metrics: Arc<Metrics>,
     pub action_metrics: Arc<Metrics>,
     pub stop: Arc<AtomicBool>,
     pub cluster_flag: Arc<AtomicBool>,
     pub server_physics: bool,
-    pub positions: Arc<SharedPositions>,
     pub all_ids: Arc<Vec<uuid::Uuid>>,
     pub total_players: Arc<AtomicU32>,
     pub actions_per_sec: f64,
@@ -266,11 +187,11 @@ pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
         total,
         tick_interval,
         metrics,
+        read_metrics,
         action_metrics,
         stop,
         cluster_flag,
         server_physics: _server_physics,
-        positions,
         all_ids,
         total_players,
         actions_per_sec,
@@ -291,12 +212,72 @@ pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
 
     let clustered = cluster_flag.load(Ordering::Relaxed);
     let mut player = Player::new(entity_id, idx, total, clustered);
-    positions.set(idx, player.x, player.z);
     let tick_dt = tick_interval.as_secs_f64();
     let mut interval = time::interval(tick_interval);
     interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
 
     let player_stdb = to_stdb_uuid(&player.id);
+
+    // Shared micros-since-run-start of this player's most recent outbound
+    // reducer call. The `on_update` callback reads this to compute
+    // client-perceived latency when SpacetimeDB delivers the subscribed
+    // `entity` row back. See the module-level docstring for the full
+    // rationale — it's the same mechanism used by `backends_arcane.rs`.
+    let last_send_micros = Arc::new(AtomicI64::new(-1));
+
+    // Register the latency hook before we subscribe, so any update that
+    // arrives during the initial applied() is counted. The SDK invokes the
+    // callback on its internal task, so the captures must be Send + 'static.
+    {
+        let last_send_hook = last_send_micros.clone();
+        let metrics_hook = metrics.clone();
+        let read_metrics_hook = read_metrics.clone();
+        let run_started_hook = run_started;
+        conn.db.entity().on_update(move |_ectx, _old, new| {
+            // Count every inbound row update as "read workload" — this is the
+            // equivalent of the byte-counting in the Arcane WS drain task.
+            read_metrics_hook.record_inbound_ok(std::mem::size_of::<Entity>() as u64);
+            if new.entity_id == player_stdb {
+                let sent = last_send_hook.load(Ordering::Relaxed);
+                if sent >= 0 {
+                    let now = run_started_hook.elapsed().as_micros() as i64;
+                    let lat_us = (now - sent).max(0) as u64;
+                    metrics_hook.record_ok(Duration::from_micros(lat_us));
+                }
+            }
+        });
+    }
+
+    // Subscribe to the player's spatial area-of-interest. Static box around
+    // the starting position — matches what a real game client's subscription
+    // would look like (entities near me) and keeps per-connection fan-out
+    // bounded. Players don't wander far during a 30 s tier at the benchmark's
+    // movement velocities, so the starting-position box is a faithful proxy.
+    //
+    // We also subscribe to the player's own row unconditionally so the
+    // latency signal stays intact even if a player drifts out of the AOI box
+    // (which shouldn't happen over 30 s but the defensive subscription is
+    // essentially free).
+    let (px0, pz0) = (player.x as i64, player.z as i64);
+    let r = VISIBILITY_RADIUS as i64;
+    let aoi_query = format!(
+        "SELECT * FROM entity WHERE x >= {} AND x <= {} AND z >= {} AND z <= {}",
+        px0 - r,
+        px0 + r,
+        pz0 - r,
+        pz0 + r,
+    );
+    let self_query = format!(
+        "SELECT * FROM entity WHERE entity_id = 0x{:032x}",
+        player_stdb.as_u128()
+    );
+    let _sub = conn
+        .subscription_builder()
+        .on_error(|_err_ctx, err| {
+            eprintln!("[stdb] subscription error: {err}");
+        })
+        .subscribe([aoi_query.as_str(), self_query.as_str()]);
+
     let mut first_tick = true;
 
     // Action timing: emit game actions at configured rate via the same
@@ -316,10 +297,9 @@ pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
             player.steer_to_point(2500.0, 2500.0);
         }
         player.tick(tick_dt, cluster_flag.load(Ordering::Relaxed));
-        positions.set(idx, player.x, player.z);
 
-        // Movement reducer call
-        let t0 = Instant::now();
+        // Movement reducer call (fire-and-forget — latency is measured by the
+        // on_update handler above).
         let result = if first_tick {
             // Insert the Entity row so subsequent input updates have something to move.
             let entity = Entity {
@@ -340,7 +320,11 @@ pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
                 .map_err(|e| e.to_string())
         };
         match result {
-            Ok(()) => metrics.record_ok(t0.elapsed()),
+            Ok(()) => {
+                // Count the successful enqueue; latency lands via on_update.
+                metrics.record_ok_count();
+                last_send_micros.store(run_started.elapsed().as_micros() as i64, Ordering::Relaxed);
+            }
             Err(e) => {
                 metrics.record_err_kind(ErrorKind::Transport);
                 if idx == 0 {
@@ -361,7 +345,6 @@ pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
                     burst_remaining = 1;
                 }
                 for _ in 0..burst_remaining {
-                    let a0 = Instant::now();
                     let result: Result<(), String> = match action {
                         GameAction::PickupItem {
                             item_type,
@@ -389,7 +372,11 @@ pub(crate) async fn player_loop_spacetimedb(ctx: SpacetimePlayerLoop) {
                         }
                     };
                     match result {
-                        Ok(()) => action_metrics.record_ok(a0.elapsed()),
+                        Ok(()) => {
+                            action_metrics.record_ok_count();
+                            last_send_micros
+                                .store(run_started.elapsed().as_micros() as i64, Ordering::Relaxed);
+                        }
                         Err(_) => action_metrics.record_err_kind(ErrorKind::Transport),
                     }
                 }
@@ -438,12 +425,5 @@ mod tests {
                 }
             }
         }
-    }
-
-    #[test]
-    fn shared_positions_roundtrip() {
-        let positions = SharedPositions::new(2);
-        positions.set(1, 42.0, -9.0);
-        assert_eq!(positions.get(1), (42.0, -9.0));
     }
 }

--- a/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
@@ -64,7 +64,6 @@ struct SpacetimeRuntime {
     /// SpacetimeDB's per-client `incoming_queue_length` limit under load and
     /// silently dropped messages — see backends_spacetimedb.rs top-of-file.
     connect_params: backends_spacetimedb::SpacetimeConnectParams,
-    sql_url: String,
     server_physics: bool,
 }
 
@@ -86,11 +85,11 @@ impl BackendRuntime for SpacetimeRuntime {
                 total: params.desired_total,
                 tick_interval: params.tick_interval,
                 metrics: shared.metrics.clone(),
+                read_metrics: shared.read_metrics.clone(),
                 action_metrics: shared.action_metrics.clone(),
                 stop: params.stop,
                 cluster_flag: shared.cluster_flag.clone(),
                 server_physics: self.server_physics,
-                positions: shared.positions.clone(),
                 all_ids: shared.all_ids.clone(),
                 total_players: shared.total_players.clone(),
                 actions_per_sec: shared.actions_per_sec,
@@ -102,24 +101,14 @@ impl BackendRuntime for SpacetimeRuntime {
 
     fn spawn_read(
         &self,
-        shared: &PlayerLoopShared,
-        params: &PlayerSpawnParams,
-        read_rate: f64,
+        _shared: &PlayerLoopShared,
+        _params: &PlayerSpawnParams,
+        _read_rate: f64,
     ) -> Option<tokio::task::JoinHandle<()>> {
-        if read_rate <= 0.0 {
-            return None;
-        }
-        Some(tokio::spawn(backends_spacetimedb::read_loop_spacetimedb(
-            backends_spacetimedb::SpacetimeReadLoop {
-                client: shared.http_client.clone(),
-                sql_url: self.sql_url.clone(),
-                read_rate,
-                read_metrics: shared.read_metrics.clone(),
-                stop: params.stop.clone(),
-                player_idx: params.idx,
-                positions: shared.positions.clone(),
-            },
-        )))
+        // SpacetimeDB reads arrive as subscription updates via the SDK — the
+        // player loop registers an `on_update(Entity)` handler inline and
+        // counts inbound bytes there. No separate read task to spawn.
+        None
     }
 }
 
@@ -170,7 +159,6 @@ impl BackendRuntime for ArcaneRuntime {
 async fn run_control_mode(cfg: Config, tick_interval: Duration) {
     let run_started = std::time::Instant::now();
     let stdb_base = cfg.spacetimedb_uri.trim_end_matches('/').to_string();
-    let sql_url = format!("{}/v1/database/{}/sql", stdb_base, cfg.database);
     // SDK requires a ws:// or wss:// URI rather than http://.
     let ws_uri = stdb_base
         .replacen("https://", "wss://", 1)
@@ -186,7 +174,6 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
                 ws_uri: ws_uri.clone(),
                 database_name: cfg.database.clone(),
             },
-            sql_url: sql_url.clone(),
             server_physics: cfg.server_physics,
         }),
         Backend::Arcane => {
@@ -276,7 +263,6 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
         .build()
         .expect("HTTP client");
 
-    let positions = Arc::new(backends_spacetimedb::SharedPositions::new(max_players));
     let cluster_flag = cfg.cluster_command.clone();
 
     // Precreate per-player stop flags so control tasks can stop everyone without synchronization.
@@ -303,7 +289,6 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
         read_metrics: read_metrics.clone(),
         action_metrics: action_metrics.clone(),
         cluster_flag: cluster_flag.clone(),
-        positions: positions.clone(),
         all_ids: all_ids.clone(),
         total_players: total_players_atomic.clone(),
         actions_per_sec: cfg.actions_per_sec,
@@ -495,7 +480,6 @@ async fn main() {
     let run_started = std::time::Instant::now();
     let tick_interval = Duration::from_micros(1_000_000 / cfg.tick_rate as u64);
     let stdb_base = cfg.spacetimedb_uri.trim_end_matches('/').to_string();
-    let sql_url = format!("{}/v1/database/{}/sql", stdb_base, cfg.database);
     let ws_uri = stdb_base
         .replacen("https://", "wss://", 1)
         .replacen("http://", "ws://", 1);
@@ -510,7 +494,6 @@ async fn main() {
                 ws_uri: ws_uri.clone(),
                 database_name: cfg.database.clone(),
             },
-            sql_url: sql_url.clone(),
             server_physics: cfg.server_physics,
         }),
         Backend::Arcane => {
@@ -560,8 +543,6 @@ async fn main() {
         .build()
         .expect("HTTP client");
 
-    let positions = Arc::new(backends_spacetimedb::SharedPositions::new(cfg.players));
-
     if backend_name == "spacetimedb" {
         eprintln!(
             "  SpacetimeDB: {}/database/{}",
@@ -573,12 +554,10 @@ async fn main() {
         eprintln!("  Arcane WS: {} (single cluster)", cfg.arcane_ws);
     }
 
-    if cfg.read_rate > 0.0 && backend_name == "spacetimedb" {
+    if backend_name == "spacetimedb" {
         eprintln!(
-            "  Read simulation: spatial queries (radius={}) at {} Hz per player ({} total queries/s)",
+            "  Read simulation: SpacetimeDB SDK subscription on `entity` in a {}-unit AOI box around each player's starting position (delivers updates via on_update, no HTTP polling).",
             VISIBILITY_RADIUS,
-            cfg.read_rate,
-            cfg.read_rate as u64 * cfg.players as u64
         );
     }
 
@@ -588,7 +567,6 @@ async fn main() {
         read_metrics: read_metrics.clone(),
         action_metrics: action_metrics.clone(),
         cluster_flag: cfg.cluster_command.clone(),
-        positions: positions.clone(),
         all_ids: all_ids.clone(),
         total_players: total_players_atomic.clone(),
         actions_per_sec: cfg.actions_per_sec,

--- a/crates/arcane-swarm/src/bin/arcane_swarm/spawn_context.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/spawn_context.rs
@@ -8,8 +8,6 @@ use std::time::Duration;
 
 use arcane_swarm::{BurstConfig, Metrics};
 
-use super::backends_spacetimedb;
-
 /// HTTP client, metric sinks, and flags shared by every player loop on a run.
 ///
 /// Action-loop config (rate, metrics, target pool) lives here too because both
@@ -21,7 +19,6 @@ pub(crate) struct PlayerLoopShared {
     pub read_metrics: Arc<Metrics>,
     pub action_metrics: Arc<Metrics>,
     pub cluster_flag: Arc<AtomicBool>,
-    pub positions: Arc<backends_spacetimedb::SharedPositions>,
     pub all_ids: Arc<Vec<uuid::Uuid>>,
     pub total_players: Arc<AtomicU32>,
     pub actions_per_sec: f64,

--- a/crates/arcane-swarm/src/metrics.rs
+++ b/crates/arcane-swarm/src/metrics.rs
@@ -115,6 +115,19 @@ impl Metrics {
         self.latency_max_us.fetch_max(us, Ordering::Relaxed);
     }
 
+    /// Record a successful operation without contributing a latency sample.
+    ///
+    /// Use this for fire-and-forget sends (reducer calls, fire-and-forget
+    /// WebSocket writes) whose call-site elapsed time is meaningless —
+    /// `socket.send()` into a local buffer returns in nanoseconds regardless
+    /// of whether the server is healthy, lagging, or dead. Latency on those
+    /// transports is measured separately by observing when the server's
+    /// outbound stream reflects the write back (see `backends_arcane` and
+    /// `backends_spacetimedb` in the binary crate).
+    pub fn record_ok_count(&self) {
+        self.ok.fetch_add(1, Ordering::Relaxed);
+    }
+
     pub fn record_ok_bytes(&self, latency: Duration, bytes: u64) {
         self.record_ok(latency);
         self.bytes.fetch_add(bytes, Ordering::Relaxed);


### PR DESCRIPTION
## Summary

The benchmark's \`lat_avg_ms\` column has been broken for a while, and four prior PRs claimed to fix it without actually fixing it:

| PR | Claimed | Did |
|---|---|---|
| #23 | "wait for Arcane ramp before measuring" | Gated *when* to measure |
| #24 | "drop per-action HTTP; persist via user_data" | Moved Arcane to fire-and-forget WS — made \`lat_avg_ms\` ~0 by design |
| #25 | "validity gate for SpacetimeDB-only" | Added a side-channel entity-count check so the harness could pass/fail without trusting latency |
| #26 | "SpacetimeDB SDK/WS client + module performance" | Moved SpacetimeDB from HTTP to SDK/WS — made \`lat_avg_ms\` ~0 by design |

The pattern: every perf optimization replaced a measurable HTTP round-trip with an unmeasurable async enqueue. Nobody restored the round-trip semantics at the metric layer — they added adjacent validity gates instead. Under production load both backends report 0 ms latency and 0 errors until the server is catastrophically gone.

## What this PR does

Replaces the enqueue-time measurement with **client-perceived latency** — the wall-clock gap between a player's outbound write and the moment the same player's own entity state is reflected back by the server. Same mechanism on both backends, producing a number that's directly comparable:

- **Arcane**: the per-player drain task decodes each incoming binary frame via \`arcane_wire::decode_server\`, walks \`DeltaPayload::updated\` for its own \`entity_id\`, and on hit records \`now - last_send\`.
- **SpacetimeDB**: each player's connection subscribes to the \`entity\` table (spatial AOI box around starting position + its own row) and registers \`on_update(Entity)\`. On each update whose row matches \`self\`, records \`now - last_send\`.

Under server load the reflection arrives late → latency rises. Under catastrophic load the reflection stops → \`NotDelivered\` / \`Transport\` / \`ConnectionDrop\` counters rise. Exactly what a real game client perceives.

## Cleanup (same PR)

Consolidating the scaffolding left behind by the prior four attempts — no parallel code paths:

- Removed the three fake \`record_ok(t0.elapsed())\` call sites in both backends. Reducer / WS-send successes now call the new \`Metrics::record_ok_count()\` (ok counter only, no latency sample) so the latency column is driven exclusively by echo matches.
- Deleted the HTTP SQL polling loop in the SpacetimeDB backend — \`read_loop_spacetimedb\`, \`SpacetimeReadLoop\`, \`SharedPositions\`. Reads now flow through the subscription. Closes the plan filed as **arcane-scaling-benchmarks #35**.
- Dropped \`sql_url\` from \`SpacetimeRuntime\` and the \`SharedPositions\` plumbing from \`PlayerLoopShared\`, main.rs, spawn_context.rs.

Supersedes **arcane-scaling-benchmarks #25** ("Phase 2: Arcane real RTT via seq_id + ACK protocol") — the echo mechanism is entirely client-side, no wire change or server change needed. Arcane cluster and SpacetimeDB modules are untouched.

## Test plan

- [x] \`cargo check -p arcane-swarm --bin arcane-swarm\`
- [x] \`cargo clippy -p arcane-swarm --all-targets -- -D warnings\`
- [x] \`cargo test -p arcane-swarm\` — all existing tests pass (10 lib + 2 bin)
- [x] \`cargo fmt --all\`
- [ ] End-to-end AWS rerun after benchmarks-repo submodule bump + image rebuild — expect \`lat_avg_ms\` to finally be a non-zero, load-responsive number

## Doc updates (filed separately in the benchmarks repo)

- \`REPRODUCIBILITY.md\` — new section "What the benchmark actually measures" explaining the semantics across both scenarios.
- \`configs/*.json\` — inline comments on \`MaxLatencyMs\` explaining what the gate actually checks.
- \`BenchmarkHarnessHelpers.ps1\` — comment at \`Parse-SwarmFinal\` pointing to the new doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)