### PR TITLE
feat(swarm): UserDataBytes — opaque per-tick user_data on PLAYER_STATE

### DIFF
--- a/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
@@ -32,8 +32,8 @@ use tokio::time;
 use tokio_tungstenite::tungstenite::Message;
 
 use arcane_swarm::{
-    encode_game_action, encode_player_state, is_zone_event_active, ArcaneEndpoint, BurstConfig,
-    CachedDelta, DeltaCache, ErrorKind, Metrics, Player,
+    encode_game_action, encode_player_state, fill_pseudo_user_data, is_zone_event_active,
+    ArcaneEndpoint, BurstConfig, CachedDelta, DeltaCache, ErrorKind, Metrics, Player,
 };
 use std::collections::HashSet;
 
@@ -115,6 +115,10 @@ pub(crate) struct ArcanePlayerLoop {
     /// entirely and reads the cached entity-id set. See `delta_cache.rs`
     /// for the architecture rationale.
     pub delta_cache: Arc<DeltaCache>,
+    /// Bytes per `PlayerStatePayload.user_data` payload. 0 = lean baseline
+    /// (the historical behavior). Set > 0 by the `--user-data-bytes` CLI
+    /// flag to measure the realistic-state ceiling.
+    pub user_data_bytes: usize,
 }
 
 /// Pick a random game action for this player at this tick.
@@ -164,6 +168,7 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
         burst,
         run_started,
         delta_cache,
+        user_data_bytes,
     } = ctx;
 
     let ws_url = resolve_arcane_ws(&endpoint, &client, idx).await;
@@ -294,6 +299,16 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
     let mut last_action = std::time::Instant::now();
     let mut action_tick: u64 = 0;
 
+    // Reusable buffer for the per-tick pseudo-user-data payload. Refilled in
+    // place each tick so the realistic-state benchmark (UserDataBytes > 0)
+    // doesn't allocate a fresh Vec on every send. Empty when user_data_bytes=0.
+    let mut user_data_buf: Vec<u8> = Vec::with_capacity(user_data_bytes);
+    // Stable per-player seed for the deterministic PRNG. Lower 64 bits of the
+    // entity UUID — varies across players, stable across ticks for the same
+    // player.
+    let user_data_seed = (player.id.as_u128() as u64) ^ (player.id.as_u128() >> 64) as u64;
+    let mut send_tick: u64 = 0;
+
     while !stop.load(Ordering::Relaxed) {
         interval.tick().await;
         if is_zone_event_active(run_started.elapsed().as_millis() as u64, burst) {
@@ -301,10 +316,27 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
         }
         player.tick(tick_dt, cluster_flag.load(Ordering::Relaxed));
 
+        send_tick = send_tick.wrapping_add(1);
+        if user_data_bytes > 0 {
+            fill_pseudo_user_data(
+                &mut user_data_buf,
+                user_data_bytes,
+                user_data_seed,
+                send_tick,
+            );
+        }
+
         // Send movement — binary postcard frame for fairness with SpacetimeDB's
         // BSATN. See brainy-bots/arcane#28 for motivation.
         let msg = encode_player_state(
-            &player.id, player.x, player.y, player.z, player.vx, player.vy, player.vz,
+            &player.id,
+            player.x,
+            player.y,
+            player.z,
+            player.vx,
+            player.vy,
+            player.vz,
+            &user_data_buf,
         );
         match sink.send(Message::Binary(msg)).await {
             Ok(_) => {

--- a/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
@@ -126,6 +126,10 @@ struct ArcaneRuntime {
     /// (rather than `PlayerLoopShared`) because it's Arcane-specific —
     /// SpacetimeDB backend has its own subscription pipeline.
     delta_cache: Arc<arcane_swarm::DeltaCache>,
+    /// Bytes per `PlayerStatePayload.user_data` payload. Same reasoning as
+    /// `delta_cache` — Arcane-specific knob; SpacetimeDB backend has no
+    /// equivalent opaque-payload field on its movement frames.
+    user_data_bytes: usize,
 }
 
 impl BackendRuntime for ArcaneRuntime {
@@ -155,6 +159,7 @@ impl BackendRuntime for ArcaneRuntime {
                 burst: shared.burst,
                 run_started: shared.run_started,
                 delta_cache: self.delta_cache.clone(),
+                user_data_bytes: self.user_data_bytes,
             },
         ))
     }
@@ -203,6 +208,7 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
             Arc::new(ArcaneRuntime {
                 endpoint,
                 delta_cache: Arc::new(arcane_swarm::DeltaCache::default()),
+                user_data_bytes: cfg.user_data_bytes,
             })
         }
     };
@@ -560,6 +566,7 @@ async fn main() {
             Arc::new(ArcaneRuntime {
                 endpoint,
                 delta_cache: Arc::new(arcane_swarm::DeltaCache::default()),
+                user_data_bytes: cfg.user_data_bytes,
             })
         }
     };

--- a/crates/arcane-swarm/src/config.rs
+++ b/crates/arcane-swarm/src/config.rs
@@ -52,6 +52,13 @@ pub struct Config {
     pub run_forever: bool,
     pub control_port: u16,
     pub burst: BurstConfig,
+    /// Bytes per `PlayerStatePayload.user_data` payload sent in the per-tick
+    /// PLAYER_STATE frame. Default 0 (lean baseline). Set > 0 to measure the
+    /// realistic-state ceiling — the Arcane backend fills the bytes per
+    /// `(player, tick)` via `protocol::fill_pseudo_user_data`. SpacetimeDB
+    /// backend ignores this knob; its `update_player` path doesn't carry an
+    /// equivalent opaque payload field.
+    pub user_data_bytes: usize,
 }
 
 pub fn parse_args() -> Config {
@@ -73,6 +80,7 @@ pub fn parse_args() -> Config {
     let mut run_forever: bool = false;
     let mut control_port: u16 = 0;
     let mut burst = BurstConfig::default();
+    let mut user_data_bytes: usize = 0;
 
     let args: Vec<String> = std::env::args().collect();
     let mut i = 1;
@@ -180,6 +188,10 @@ pub fn parse_args() -> Config {
                 i += 1;
                 burst.zone_event_window_ms = args[i].parse().unwrap_or(burst.zone_event_window_ms);
             }
+            "--user-data-bytes" => {
+                i += 1;
+                user_data_bytes = args[i].parse().unwrap_or(0);
+            }
             "--help" | "-h" => {
                 eprintln!("arcane-swarm: headless client swarm\n");
                 eprintln!("  --backend MODE        spacetimedb | arcane (default spacetimedb)");
@@ -209,6 +221,7 @@ pub fn parse_args() -> Config {
                 );
                 eprintln!("  --zone-event-period-secs N seconds between all-player convergence events (default 30)");
                 eprintln!("  --zone-event-window-ms N zone event steering window in milliseconds (default 500)");
+                eprintln!("  --user-data-bytes N    bytes per PLAYER_STATE.user_data payload (default 0; Arcane backend only)");
                 eprintln!("  --csv PATH             write metrics CSV to this file");
                 eprintln!(
                     "  --uri URL              SpacetimeDB URI (default http://127.0.0.1:3000)"
@@ -246,5 +259,6 @@ pub fn parse_args() -> Config {
         run_forever,
         control_port,
         burst,
+        user_data_bytes,
     }
 }

--- a/crates/arcane-swarm/src/lib.rs
+++ b/crates/arcane-swarm/src/lib.rs
@@ -30,5 +30,7 @@ pub use delta_cache::{CachedDelta, DeltaCache};
 pub use engine_api::{EngineRunConfig, EngineRunHandle, EngineSummary, SwarmEngine};
 pub use metrics::{ErrorBreakdown, ErrorKind, Metrics, MetricsSnapshot};
 pub use player::Player;
-pub use protocol::{encode_game_action, encode_player_state, VISIBILITY_RADIUS};
+pub use protocol::{
+    encode_game_action, encode_player_state, fill_pseudo_user_data, VISIBILITY_RADIUS,
+};
 pub use reporter::{fmt_bytes, run_reporter, sample_proc, ReporterConfig};

--- a/crates/arcane-swarm/src/protocol.rs
+++ b/crates/arcane-swarm/src/protocol.rs
@@ -17,6 +17,14 @@ pub const VISIBILITY_RADIUS: f64 = 1500.0;
 
 /// Encode one `PLAYER_STATE` frame as postcard bytes for the Arcane cluster
 /// WebSocket. Returned bytes are ready to send as `Message::Binary`.
+///
+/// `user_data` is opaque per-entity payload that flows through the cluster's
+/// existing `EntityStateEntry.user_data` path back out to subscribers. Pass an
+/// empty slice for the lean baseline; for the realistic-state benchmark the
+/// caller fills it via [`fill_pseudo_user_data`] so the wire carries varied
+/// (not constant-zero) bytes — important for a fair comparison once
+/// per-message-deflate (arcane#44) is enabled.
+#[allow(clippy::too_many_arguments)]
 pub fn encode_player_state(
     id: &uuid::Uuid,
     x: f64,
@@ -25,17 +33,58 @@ pub fn encode_player_state(
     vx: f64,
     vy: f64,
     vz: f64,
+    user_data: &[u8],
 ) -> Vec<u8> {
     let frame = ClientFrame::PlayerState(PlayerStatePayload {
         entity_id: *id,
         position: WireVec3::new(x, y, z),
         velocity: WireVec3::new(vx, vy, vz),
-        user_data: Vec::new(),
+        user_data: user_data.to_vec(),
     });
     // encode_client returns Err only on allocator failure or serialize-bug;
     // both are fatal rather than recoverable for a benchmark client — unwrap
     // so any such bug fails loudly instead of silently dropping messages.
     encode_client(&frame).expect("postcard encode of ClientFrame::PlayerState cannot fail")
+}
+
+/// Fill `buf` with `len` deterministic-but-varied bytes derived from
+/// `(player_seed, tick)`. Caller-owned buffer so the swarm's per-tick path
+/// reuses a single allocation per player instead of allocating fresh.
+///
+/// Why deterministic-but-varied:
+/// - **Reproducibility**: same `(seed, tick)` ⇒ same bytes. A future PR that
+///   adds a regression check for "did UserDataBytes change broadcast wire
+///   bytes?" can compare runs apples-to-apples.
+/// - **Not constant**: a constant payload (e.g. `vec![0u8; len]`) compresses
+///   to near-nothing under per-message-deflate. That would make the realistic
+///   measurement accidentally measure "PMD on highly-redundant data" rather
+///   than "realistic game payload over the wire". xorshift output has the
+///   compression characteristics of typical mixed game state — some structure
+///   but not uniformly redundant.
+///
+/// Uses xorshift64* (Marsaglia, 2003): 1 multiplication + 3 shifts + 3 xors
+/// per 8 bytes. Negligible cost vs the encode + send path, and it matches the
+/// "cheap PRNG" caveat in arcane-scaling-benchmarks#52.
+pub fn fill_pseudo_user_data(buf: &mut Vec<u8>, len: usize, player_seed: u64, tick: u64) {
+    buf.clear();
+    if len == 0 {
+        return;
+    }
+    buf.reserve_exact(len);
+    let mut state =
+        player_seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ tick.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    if state == 0 {
+        state = 0xDEAD_BEEF_CAFE_BABE;
+    }
+    while buf.len() < len {
+        state ^= state >> 12;
+        state ^= state << 25;
+        state ^= state >> 27;
+        let out = state.wrapping_mul(0x2545_F491_4F6C_DD1D);
+        let bytes = out.to_le_bytes();
+        let take = (len - buf.len()).min(8);
+        buf.extend_from_slice(&bytes[..take]);
+    }
 }
 
 /// Encode one `GAME_ACTION` frame as postcard bytes for the Arcane cluster
@@ -58,7 +107,7 @@ mod tests {
     #[test]
     fn encode_player_state_roundtrips() {
         let id = uuid::Uuid::from_u128(0x1111_2222);
-        let bytes = encode_player_state(&id, 1.25, 2.5, 3.75, 0.1, 0.0, -0.1);
+        let bytes = encode_player_state(&id, 1.25, 2.5, 3.75, 0.1, 0.0, -0.1, &[]);
         let decoded = decode_client(&bytes).unwrap();
         let ClientFrame::PlayerState(payload) = decoded else {
             panic!("expected PlayerState variant");
@@ -67,6 +116,53 @@ mod tests {
         assert_eq!(payload.position.x, 1.25);
         assert_eq!(payload.velocity.z, -0.1);
         assert!(payload.user_data.is_empty());
+    }
+
+    #[test]
+    fn encode_player_state_carries_user_data() {
+        let id = uuid::Uuid::from_u128(7);
+        let payload = vec![0xAB, 0xCD, 0xEF, 0x12, 0x34];
+        let bytes = encode_player_state(&id, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, &payload);
+        let decoded = decode_client(&bytes).unwrap();
+        let ClientFrame::PlayerState(p) = decoded else {
+            panic!("expected PlayerState variant");
+        };
+        assert_eq!(p.user_data, payload);
+    }
+
+    #[test]
+    fn fill_pseudo_user_data_is_deterministic_per_seed_tick() {
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        fill_pseudo_user_data(&mut a, 100, 42, 1000);
+        fill_pseudo_user_data(&mut b, 100, 42, 1000);
+        assert_eq!(a, b, "same (seed, tick) must produce identical bytes");
+        assert_eq!(a.len(), 100);
+    }
+
+    #[test]
+    fn fill_pseudo_user_data_varies_across_ticks() {
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        fill_pseudo_user_data(&mut a, 64, 42, 1000);
+        fill_pseudo_user_data(&mut b, 64, 42, 1001);
+        assert_ne!(a, b, "consecutive ticks must produce different bytes");
+    }
+
+    #[test]
+    fn fill_pseudo_user_data_varies_across_players() {
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        fill_pseudo_user_data(&mut a, 64, 42, 1000);
+        fill_pseudo_user_data(&mut b, 64, 43, 1000);
+        assert_ne!(a, b, "different player seeds must produce different bytes");
+    }
+
+    #[test]
+    fn fill_pseudo_user_data_zero_length_is_empty() {
+        let mut buf = vec![0xFFu8; 16];
+        fill_pseudo_user_data(&mut buf, 0, 1, 1);
+        assert!(buf.is_empty(), "len=0 must clear the buffer");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Swarm side of brainy-bots/arcane-scaling-benchmarks#52 — let the realistic-state benchmark carry a non-trivial \`user_data\` payload on each PLAYER_STATE frame.

- New \`protocol::fill_pseudo_user_data(buf, len, seed, tick)\` fills a caller-owned Vec with deterministic-but-varied bytes via xorshift64*.
- \`encode_player_state\` gains a \`user_data: &[u8]\` arg. Empty slice preserves the lean baseline.
- \`Config.user_data_bytes: usize\` + \`--user-data-bytes N\` CLI flag (default 0; SpacetimeDB backend ignores it).
- Per-player loop reuses one Vec across ticks (no per-tick allocation when size is 0).

## Why xorshift64* and not zeros

A constant payload compresses to near-nothing under per-message-deflate (arcane#44, lands next). That would make the realistic-state benchmark accidentally measure \"PMD on highly-redundant data\" rather than \"realistic game payload over the wire.\"

## Test plan

- [x] \`encode_player_state_carries_user_data\` — wire roundtrip with bytes
- [x] \`fill_pseudo_user_data\` determinism + variation across ticks/players + zero-length
- [x] All 15 swarm unit tests pass (5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)