### PR TITLE
feat(swarm): quantize PLAYER_STATE position+velocity at the wire boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
 [[package]]
 name = "arcane-wire"
 version = "0.1.0"
-source = "git+https://github.com/brainy-bots/arcane.git?branch=main#5aa2ab4fb5e8fb966e90264b75068605fd378bb7"
+source = "git+https://github.com/brainy-bots/arcane.git?branch=main#1af872dc7c3b9fa5f70f5d7bddc842f719becd01"
 dependencies = [
  "postcard",
  "serde",
@@ -2429,7 +2429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/arcane-swarm/src/protocol.rs
+++ b/crates/arcane-swarm/src/protocol.rs
@@ -9,7 +9,7 @@
 //! default — see brainy-bots/arcane#28 for the motivation + microbench.
 
 use arcane_wire::{
-    encode_client, ClientFrame, GameActionPayload, PlayerStatePayload, Vec3 as WireVec3,
+    encode_client, ClientFrame, GameActionPayload, PlayerStatePayload, Vec3 as WireVec3, Vec3Q,
 };
 
 /// Spatial query radius (server units) for SpacetimeDB read simulation.
@@ -35,10 +35,15 @@ pub fn encode_player_state(
     vz: f64,
     user_data: &[u8],
 ) -> Vec<u8> {
+    // Quantize at the wire boundary: continuous f64 from the simulated
+    // player tick becomes i16 on the wire (~3-9 B per Vec3 vs 24 B). See
+    // arcane_wire::Vec3Q for the scale + range tradeoff. Sub-unit precision
+    // is lost; the benchmark world's noise floor (collision_radius=50) is
+    // well above 1 unit so this is invisible to the kinematic sim.
     let frame = ClientFrame::PlayerState(PlayerStatePayload {
         entity_id: *id,
-        position: WireVec3::new(x, y, z),
-        velocity: WireVec3::new(vx, vy, vz),
+        position: Vec3Q::from_vec3(WireVec3::new(x, y, z)),
+        velocity: Vec3Q::from_vec3(WireVec3::new(vx, vy, vz)),
         user_data: user_data.to_vec(),
     });
     // encode_client returns Err only on allocator failure or serialize-bug;
@@ -113,8 +118,9 @@ mod tests {
             panic!("expected PlayerState variant");
         };
         assert_eq!(payload.entity_id, id);
-        assert_eq!(payload.position.x, 1.25);
-        assert_eq!(payload.velocity.z, -0.1);
+        // Vec3Q quantization: 1.25 rounds to 1; -0.1 rounds to 0.
+        assert_eq!(payload.position.x, 1i16);
+        assert_eq!(payload.velocity.z, 0i16);
         assert!(payload.user_data.is_empty());
     }
 


### PR DESCRIPTION
## Summary

Companion to brainy-bots/arcane#49 (Vec3 → Vec3Q on the wire). The swarm now quantizes f64 position/velocity into i16 at encode time before sending PLAYER_STATE to the cluster.

- \`protocol::encode_player_state\` wraps the f64 args with \`Vec3Q::from_vec3\` before constructing \`PlayerStatePayload\`.
- Cargo.lock bumped to pull in the new arcane-wire schema (1af872dc).
- The drain task is unaffected: it reads only \`entity_id\` (Uuid) and \`server_ts\` (f64); position/velocity are not dereferenced by the latency decomposition path.

## Test plan

- [x] All 15 swarm unit tests pass. \`encode_player_state_roundtrips\` updated to assert on the rounded i16 values (1.25 → 1, -0.1 → 0) since the wire roundtrip discards sub-unit precision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)