### PR TITLE
fix(swarm): user_data must be valid JSON; wrap xorshift in `{"d":"<hex>"}` envelope

### DIFF
--- a/crates/arcane-swarm/src/protocol.rs
+++ b/crates/arcane-swarm/src/protocol.rs
@@ -52,44 +52,75 @@ pub fn encode_player_state(
     encode_client(&frame).expect("postcard encode of ClientFrame::PlayerState cannot fail")
 }
 
-/// Fill `buf` with `len` deterministic-but-varied bytes derived from
-/// `(player_seed, tick)`. Caller-owned buffer so the swarm's per-tick path
-/// reuses a single allocation per player instead of allocating fresh.
+/// Fill `buf` with approximately `len` bytes of deterministic-but-varied
+/// JSON-shaped payload derived from `(player_seed, tick)`. Caller-owned
+/// buffer so the swarm's per-tick path reuses a single allocation per
+/// player.
+///
+/// Output shape: `{"d":"<hex>"}` where `<hex>` is the hex encoding of
+/// xorshift64* bytes. Total length lands within ±1 byte of `len` for
+/// `len >= 10`; smaller `len` clamps up to a 10-byte minimum so the
+/// envelope stays a valid JSON object.
+///
+/// **Why JSON-shaped, not raw bytes.** The cluster's
+/// `entry_from_wire_player_state` calls `serde_json::from_slice` on the
+/// wire's `user_data` field. Raw entropy bytes aren't valid JSON and
+/// every PlayerState was rejected (parse_failure) — discovered during
+/// the 2026-04-26 realistic-state run E. The hex envelope is the cheap
+/// fix: stays JSON-parseable on the cluster side; the hex content keeps
+/// the entropy that was the original goal of this helper (so PMD
+/// compression measurements aren't accidentally measuring "compressing
+/// constant zeros"); the envelope adds only ~8 bytes of structural
+/// overhead.
+///
+/// **Why hex and not base64.** Hex needs no extra crate dependency, has
+/// a fixed 2× expansion factor (so length math is predictable), and uses
+/// only characters that are JSON-safe with no escape sequences. base64
+/// would be denser but requires either a dep or hand-written encoder for
+/// no benchmark-relevant gain.
 ///
 /// Why deterministic-but-varied:
-/// - **Reproducibility**: same `(seed, tick)` ⇒ same bytes. A future PR that
-///   adds a regression check for "did UserDataBytes change broadcast wire
-///   bytes?" can compare runs apples-to-apples.
-/// - **Not constant**: a constant payload (e.g. `vec![0u8; len]`) compresses
-///   to near-nothing under per-message-deflate. That would make the realistic
-///   measurement accidentally measure "PMD on highly-redundant data" rather
-///   than "realistic game payload over the wire". xorshift output has the
-///   compression characteristics of typical mixed game state — some structure
-///   but not uniformly redundant.
-///
-/// Uses xorshift64* (Marsaglia, 2003): 1 multiplication + 3 shifts + 3 xors
-/// per 8 bytes. Negligible cost vs the encode + send path, and it matches the
-/// "cheap PRNG" caveat in arcane-scaling-benchmarks#52.
+/// - **Reproducibility**: same `(seed, tick)` ⇒ same bytes.
+/// - **Not constant**: a constant payload compresses to near-nothing
+///   under per-message-deflate (arcane#44 when it lands). That would
+///   make the realistic-state measurement accidentally measure "PMD on
+///   highly-redundant data" rather than "realistic game payload".
 pub fn fill_pseudo_user_data(buf: &mut Vec<u8>, len: usize, player_seed: u64, tick: u64) {
     buf.clear();
     if len == 0 {
         return;
     }
-    buf.reserve_exact(len);
+    // Envelope `{"d":""}` is 8 bytes; hex content is 2 bytes per raw byte.
+    // Smallest valid envelope is `{"d":"00"}` = 10 bytes — clamp `len` up.
+    let target = len.max(10);
+    let raw_len = (target - 8) / 2;
+    let mut raw: Vec<u8> = Vec::with_capacity(raw_len.max(1));
     let mut state =
         player_seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ tick.wrapping_mul(0xBF58_476D_1CE4_E5B9);
     if state == 0 {
         state = 0xDEAD_BEEF_CAFE_BABE;
     }
-    while buf.len() < len {
+    while raw.len() < raw_len {
         state ^= state >> 12;
         state ^= state << 25;
         state ^= state >> 27;
         let out = state.wrapping_mul(0x2545_F491_4F6C_DD1D);
         let bytes = out.to_le_bytes();
-        let take = (len - buf.len()).min(8);
-        buf.extend_from_slice(&bytes[..take]);
+        let take = (raw_len - raw.len()).min(8);
+        raw.extend_from_slice(&bytes[..take]);
     }
+    let mut hex = String::with_capacity(raw.len() * 2);
+    for b in &raw {
+        use std::fmt::Write;
+        let _ = write!(hex, "{:02x}", b);
+    }
+    // serde_json::to_vec emits compact JSON (no whitespace) so the byte
+    // length matches the envelope-overhead-plus-hex math above.
+    let mut payload = serde_json::Map::new();
+    payload.insert("d".to_string(), serde_json::Value::String(hex));
+    let bytes = serde_json::to_vec(&serde_json::Value::Object(payload))
+        .expect("serializing a tiny JSON map cannot fail");
+    buf.extend_from_slice(&bytes);
 }
 
 /// Encode one `GAME_ACTION` frame as postcard bytes for the Arcane cluster
@@ -143,6 +174,8 @@ mod tests {
         fill_pseudo_user_data(&mut a, 100, 42, 1000);
         fill_pseudo_user_data(&mut b, 100, 42, 1000);
         assert_eq!(a, b, "same (seed, tick) must produce identical bytes");
+        // Length: 8-byte envelope + 2 × raw_len hex chars; raw_len = (100-8)/2 = 46.
+        // Total = 8 + 92 = 100. The math is exact for even (len-8).
         assert_eq!(a.len(), 100);
     }
 
@@ -169,6 +202,40 @@ mod tests {
         let mut buf = vec![0xFFu8; 16];
         fill_pseudo_user_data(&mut buf, 0, 1, 1);
         assert!(buf.is_empty(), "len=0 must clear the buffer");
+    }
+
+    #[test]
+    fn fill_pseudo_user_data_output_is_valid_json() {
+        // The whole point of the JSON-envelope rewrite: the cluster's
+        // serde_json::from_slice must succeed on the bytes this produces.
+        // Run E rejected every PlayerState because raw entropy bytes
+        // weren't valid JSON; this is the regression test that prevents
+        // a future refactor from re-breaking the wire/cluster contract.
+        for len in [10usize, 50, 100, 500] {
+            let mut buf = Vec::new();
+            fill_pseudo_user_data(&mut buf, len, 42, 7);
+            let parsed: serde_json::Value =
+                serde_json::from_slice(&buf).expect("output must parse as JSON");
+            assert!(
+                parsed.get("d").and_then(|v| v.as_str()).is_some(),
+                "envelope must carry the hex payload under key `d`"
+            );
+        }
+    }
+
+    #[test]
+    fn fill_pseudo_user_data_clamps_small_len_to_minimum_envelope() {
+        // Anything below the 10-byte minimum envelope size produces a
+        // 10-byte output. Documented behavior — callers asking for
+        // tiny `len` don't get tiny output, they get the smallest valid
+        // JSON envelope.
+        for len in [1usize, 5, 9] {
+            let mut buf = Vec::new();
+            fill_pseudo_user_data(&mut buf, len, 1, 1);
+            assert_eq!(buf.len(), 10, "len={} must clamp to 10-byte minimum", len);
+            let _: serde_json::Value =
+                serde_json::from_slice(&buf).expect("clamped output must still be valid JSON");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the wire/cluster contract bug surfaced during 2026-04-26 Run E: every PlayerState rejected because raw xorshift bytes aren't valid JSON, but the cluster's \`entry_from_wire_player_state\` calls \`serde_json::from_slice\` on the wire's \`user_data\` field. Discovered with 683k parse failures and 0 entities ever registered.

This is option A from the resolution comment on brainy-bots/arcane-scaling-benchmarks#52: wrap the xorshift bytes in a small JSON envelope so the cluster's parse path succeeds.

## Output shape

\`{\"d\":\"<hex>\"}\` where \`<hex>\` is the hex encoding of xorshift64* bytes.

- **Hex (not base64):** no extra crate dependency, fixed 2× expansion factor → exact length math.
- **For \`len = 100\`:** 8-byte envelope + 92 hex chars (= 46 raw bytes × 2) = exactly 100.
- **Length clamps to 10-byte minimum** so the envelope is always valid JSON (smallest: \`{\"d\":\"00\"}\`).

## Test plan

- 2 new regression tests:
  - \`fill_pseudo_user_data_output_is_valid_json\` — across len=10/50/100/500, output is JSON-parseable and the envelope carries the hex payload under key \`d\`. This is the test that would have caught the original bug.
  - \`fill_pseudo_user_data_clamps_small_len_to_minimum_envelope\` — len=1/5/9 all produce a 10-byte valid JSON output.
- Existing length test (\`fill_pseudo_user_data_is_deterministic_per_seed_tick\`) still expects exactly 100 bytes for len=100 — math works out the same.
- All 17 swarm unit tests pass.

## Out of scope

Option B (cluster treats user_data as opaque \`Vec<u8>\` end-to-end and removes the JSON parse) is the cleaner architectural fix. Larger change touching the cluster, the L1 SpacetimeDB persist path, and multiple repos. Worth filing as a separate arcane issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)