### PR TITLE
Use Haiku with Opus advisor; bypass tool-permission prompts

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--model haiku --dangerously-skip-permissions"
+          settings: '{"advisorModel": "opus"}'
           prompt: |
             Pick up GitHub issue #${{ github.event.issue.number }} in this repo: "${{ github.event.issue.title }}".
 


### PR DESCRIPTION
First real agent run on issue #8 (run [25046440558](https://github.com/brainy-bots/arcane_swarm/actions/runs/25046440558)) succeeded at the SDK level but produced nothing — no PR, no branch, no issue comment — because of **38 tool-permission denials**. In the GitHub Actions runner there's no interactive prompt, so the default Claude Code permission gate auto-denies every Bash/Edit/Write call. The agent spent 11 min and \$1.47-equivalent of subscription quota looping on retries, then exited cleanly.

Run also used the action's default model (Sonnet) because no `--model` was set in the original bootstrap. We agreed Haiku-as-executor + Opus-as-advisor is the cost-aware split.

## Changes

- `claude_args: "--model haiku --dangerously-skip-permissions"` — switch executor to Haiku and bypass the in-runner tool-permission gate (which has no interactive prompt available anyway).
- `settings: '{"advisorModel": "opus"}'` — Opus consulted on hard tactical calls during execution.

## Notes

- `--dangerously-skip-permissions` is the cheapest unblocker for the first end-to-end run. We can tighten to a per-tool allowlist (`--allowedTools "Bash(git*),Bash(cargo*),Edit,Write,Read,Glob,Grep"`) once we've seen what Haiku actually needs.
- Caveman / concise-output prompt rule is intentionally NOT bundled here — easier to attribute behavior changes if model swap and prompt changes land separately.
- This PR is `arcane_swarm`-only on purpose. If issue #8 succeeds end-to-end after this lands, the same change propagates to `arcane` and `arcane-scaling-benchmarks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)