### PR TITLE
ci: add release build step and --workspace to clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,10 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Test
         run: cargo test --all --all-features
+
+      - name: Release build
+        run: cargo build --release --workspace


### PR DESCRIPTION
Resolves #3.

## Changes

- `cargo clippy` now runs with `--workspace` (matches arcane repo's pattern, lints all crates).
- Added a `Release build` step after `Test` that runs `cargo build --release --workspace`.

## Why this PR (not an agent run)

Issue #3 was originally labeled `claude-ready` and the agent run completed without producing any artifact — workflow YAML is outside the cloud-agent loop because the auto-provisioned `GITHUB_TOKEN` lacks the `workflow` scope needed to push commits modifying `.github/workflows/*`. CI changes are terminal-side work going forward.

## Out of scope (per refined #3 spec)

- Branch deletion / `master` redirect — local default-branch state is a manual ops action.
- Trigger changes — current `branches: ["main"]` stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)