### PR TITLE
chore: disable claude-code-action workflow — local daemon handles dispatch

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -1,0 +1,12 @@
+name: Claude on labeled issue
+# DISABLED: Local daemon handles worker dispatch. CI would burn Claude Code API quota.
+# Keeping the workflow definition for reference only.
+on:
+  workflow_dispatch:
+
+jobs:
+  claude:
+    if: false
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Worker CI disabled — local daemon handles this."


### PR DESCRIPTION
Same rationale as arcane-engine: the CI-based `anthropics/claude-code-action@v1` workflow races with the local daemon and burns API quota. Disabling.