### PR TITLE
feat(swarm): #27 driver protocol extension — orchestrated mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,7 @@ dependencies = [
 name = "arcane-swarm"
 version = "0.1.0"
 dependencies = [
+ "arcane-swarm-orchestrator",
  "arcane-wire",
  "futures-util",
  "libc",

--- a/crates/arcane-swarm/Cargo.toml
+++ b/crates/arcane-swarm/Cargo.toml
@@ -24,6 +24,10 @@ spacetimedb-sdk = "2.1"
 # both arcane and arcane_swarm as submodules, so this resolves to the
 # same commit in the benchmark CI.
 arcane-wire = { git = "https://github.com/brainy-bots/arcane.git", branch = "main" }
+# Shared orchestrator wire schema (DriverMessage / OrchestratorResponse /
+# OrchestratorCommand / CommandAck). The orchestrator crate is the source of
+# truth for these types; the driver consumes them under --orchestrator-url.
+arcane-swarm-orchestrator = { path = "../arcane-swarm-orchestrator" }
 
 [[bin]]
 name = "arcane-swarm"

--- a/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
@@ -32,6 +32,8 @@ mod backends_spacetimedb;
 mod spacetimedb_bindings;
 mod spawn_context;
 
+use arcane_swarm::orchestrated_mode;
+
 use spawn_context::{
     spawn_control_mode_player, ControlSpawnKit, PlayerLoopShared, PlayerSpawnParams,
 };
@@ -601,6 +603,14 @@ async fn main() {
         }
     };
     let backend_name = backend_runtime.name();
+
+    if cfg.orchestrator_url.is_some() {
+        if let Err(e) = orchestrated_mode::run_orchestrated_mode(cfg).await {
+            eprintln!("arcane-swarm(orchestrated): {}", e);
+            std::process::exit(1);
+        }
+        return;
+    }
 
     if cfg.run_forever || cfg.control_port > 0 {
         run_control_mode(cfg, tick_interval).await;

--- a/crates/arcane-swarm/src/config.rs
+++ b/crates/arcane-swarm/src/config.rs
@@ -73,6 +73,11 @@ pub struct Config {
     /// into the soft-saturation zone where measurements become unreliable —
     /// the orchestrator must provision more drivers instead.
     pub max_players_per_driver: u32,
+    /// When set, the driver runs in orchestrated mode: connects to the named
+    /// swarm orchestrator over WebSocket, registers, listens for commands,
+    /// and acks. Mutually exclusive with the standalone player-spawning path.
+    /// When unset (default), the driver runs in standalone mode unchanged.
+    pub orchestrator_url: Option<String>,
 }
 
 pub fn parse_args() -> Config {
@@ -97,6 +102,7 @@ pub fn parse_args() -> Config {
     let mut user_data_bytes: usize = 0;
     let mut inter_spawn_delay_ms: u32 = 0;
     let mut max_players_per_driver: u32 = 0;
+    let mut orchestrator_url: Option<String> = std::env::var("ORCHESTRATOR_URL").ok();
 
     let args: Vec<String> = std::env::args().collect();
     let mut i = 1;
@@ -216,6 +222,10 @@ pub fn parse_args() -> Config {
                 i += 1;
                 max_players_per_driver = args[i].parse().unwrap_or(0);
             }
+            "--orchestrator-url" => {
+                i += 1;
+                orchestrator_url = Some(args[i].clone());
+            }
             "--help" | "-h" => {
                 eprintln!("arcane-swarm: headless client swarm\n");
                 eprintln!("  --backend MODE        spacetimedb | arcane (default spacetimedb)");
@@ -248,6 +258,7 @@ pub fn parse_args() -> Config {
                 eprintln!("  --user-data-bytes N    bytes per PLAYER_STATE.user_data payload (default 0; Arcane backend only)");
                 eprintln!("  --inter-spawn-delay-ms N  ms between consecutive player spawns (default 0; multi-driver join-rate pacing)");
                 eprintln!("  --max-players-per-driver N  hard safety cap on simultaneously-active players (default 0 = no cap; multi-driver runs set this conservatively)");
+                eprintln!("  --orchestrator-url URL  connect to swarm orchestrator over WS and run in orchestrated mode (default unset = standalone)");
                 eprintln!("  --csv PATH             write metrics CSV to this file");
                 eprintln!(
                     "  --uri URL              SpacetimeDB URI (default http://127.0.0.1:3000)"
@@ -288,5 +299,6 @@ pub fn parse_args() -> Config {
         user_data_bytes,
         inter_spawn_delay_ms,
         max_players_per_driver,
+        orchestrator_url,
     }
 }

--- a/crates/arcane-swarm/src/lib.rs
+++ b/crates/arcane-swarm/src/lib.rs
@@ -19,6 +19,7 @@ pub mod config;
 pub mod delta_cache;
 pub mod engine_api;
 pub mod metrics;
+pub mod orchestrated_mode;
 pub mod orchestration;
 pub mod player;
 pub mod protocol;

--- a/crates/arcane-swarm/src/orchestrated_mode.rs
+++ b/crates/arcane-swarm/src/orchestrated_mode.rs
@@ -1,0 +1,268 @@
+//! Orchestrated mode for the swarm driver.
+//!
+//! When the operator passes `--orchestrator-url <url>`, the driver connects
+//! to a swarm orchestrator over WebSocket, registers, sends periodic
+//! heartbeats, and applies real-time commands (`SetPlayers`, `SetSpawnDelayMs`,
+//! `Stop`) by updating shared atomics. Each command is acknowledged with a
+//! `CommandAck` carrying the orchestrator-assigned sequence number.
+//!
+//! **Scope of this module.** This is the wire-protocol half of the driver
+//! protocol extension (#27). It maintains the `target_players` and
+//! `spawn_delay_ms` state mutated by orchestrator commands, but does **not**
+//! drive the existing per-player spawning machinery — wiring that state into
+//! the live spawn loop is a follow-up. The contract this PR satisfies:
+//! "registration succeeds, commands received, telemetry pushed."
+//!
+//! Standalone mode (no `--orchestrator-url`) is unchanged.
+
+use crate::{Backend, Config};
+use arcane_swarm_orchestrator::protocol::{
+    CommandAck, CommandEnvelope, DeregisterRequest, DriverMessage, HeartbeatRequest,
+    OrchestratorCommand, OrchestratorResponse, RegisterRequest,
+};
+use futures_util::{SinkExt, StreamExt};
+use serde_json::json;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+/// Shared state mutated by orchestrator commands. Public so a future PR
+/// (driving the existing spawn loop from these atomics) can read them.
+#[derive(Clone)]
+pub struct OrchestratedState {
+    pub target_players: Arc<AtomicU32>,
+    pub spawn_delay_ms: Arc<AtomicU32>,
+    pub stop: Arc<AtomicBool>,
+}
+
+impl OrchestratedState {
+    pub fn new(initial_players: u32, initial_spawn_delay_ms: u32) -> Self {
+        Self {
+            target_players: Arc::new(AtomicU32::new(initial_players)),
+            spawn_delay_ms: Arc::new(AtomicU32::new(initial_spawn_delay_ms)),
+            stop: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+/// Connect, register, run the heartbeat + command loop until either the
+/// orchestrator disconnects or a `Stop` command is received.
+pub async fn run_orchestrated_mode(cfg: Config) -> Result<(), String> {
+    let url = cfg
+        .orchestrator_url
+        .clone()
+        .expect("run_orchestrated_mode requires --orchestrator-url");
+
+    eprintln!(
+        "arcane-swarm(orchestrated): connecting to {} (initial players={}, spawn_delay_ms={})",
+        url, cfg.players, cfg.inter_spawn_delay_ms
+    );
+
+    let (ws, _) = connect_async(&url).await.map_err(|e| e.to_string())?;
+    let (mut sender, mut receiver) = ws.split();
+
+    let register = DriverMessage::Register(RegisterRequest {
+        capabilities: json!({
+            "binary": "arcane-swarm",
+            "backend": match cfg.backend {
+                Backend::SpacetimeDb => "spacetimedb",
+                Backend::Arcane => "arcane",
+            },
+            "max_players": cfg.max_players,
+            "tick_rate": cfg.tick_rate,
+        }),
+    });
+    sender
+        .send(Message::Text(serde_json::to_string(&register).unwrap()))
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let driver_id = match receiver.next().await {
+        Some(Ok(msg)) if msg.is_text() => {
+            let resp: OrchestratorResponse =
+                serde_json::from_str(msg.to_text().unwrap()).map_err(|e| e.to_string())?;
+            match resp {
+                OrchestratorResponse::Ack(ack) => ack
+                    .driver_id
+                    .ok_or_else(|| "register ack missing driver_id".to_string())?,
+                OrchestratorResponse::RegisterRejected(r) => {
+                    return Err(format!("orchestrator rejected register: {}", r.reason));
+                }
+                other => return Err(format!("unexpected register response: {:?}", other)),
+            }
+        }
+        other => {
+            return Err(format!(
+                "no register response from orchestrator: {:?}",
+                other
+            ))
+        }
+    };
+    eprintln!("arcane-swarm(orchestrated): registered as {}", driver_id);
+
+    let state = OrchestratedState::new(cfg.players, cfg.inter_spawn_delay_ms);
+
+    // Heartbeat task. Independent of the read loop so missed heartbeats are
+    // determined by wall-clock cadence, not message arrival rate.
+    let (hb_tx, mut hb_rx) = tokio::sync::mpsc::channel::<DriverMessage>(8);
+    let hb_state_stop = state.stop.clone();
+    tokio::spawn(async move {
+        let mut ticker = time::interval(Duration::from_secs(5));
+        loop {
+            ticker.tick().await;
+            if hb_state_stop.load(Ordering::Relaxed) {
+                return;
+            }
+            if hb_tx
+                .send(DriverMessage::Heartbeat(HeartbeatRequest { driver_id }))
+                .await
+                .is_err()
+            {
+                return;
+            }
+        }
+    });
+
+    // Outbound multiplexer: writes Heartbeat (from hb_rx) + CommandAck (from
+    // ack_tx) onto the single WS sink.
+    let (ack_tx, mut ack_rx) = tokio::sync::mpsc::channel::<DriverMessage>(64);
+    let writer_stop = state.stop.clone();
+    let writer = tokio::spawn(async move {
+        loop {
+            if writer_stop.load(Ordering::Relaxed) {
+                return;
+            }
+            tokio::select! {
+                Some(msg) = hb_rx.recv() => {
+                    if sender
+                        .send(Message::Text(serde_json::to_string(&msg).unwrap()))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+                Some(msg) = ack_rx.recv() => {
+                    if sender
+                        .send(Message::Text(serde_json::to_string(&msg).unwrap()))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+                else => return,
+            }
+        }
+    });
+
+    // Read loop: process orchestrator-pushed messages.
+    while let Some(msg_result) = receiver.next().await {
+        let msg = match msg_result {
+            Ok(m) => m,
+            Err(_) => break,
+        };
+        if msg.is_close() {
+            break;
+        }
+        if !msg.is_text() {
+            continue;
+        }
+        let text = msg.to_text().unwrap_or("");
+        let resp: OrchestratorResponse = match serde_json::from_str(text) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        match resp {
+            OrchestratorResponse::Command(env) => {
+                apply_command(&state, &env);
+                let ack = DriverMessage::CommandAck(CommandAck {
+                    driver_id,
+                    command_seq: env.seq,
+                });
+                let _ = ack_tx.send(ack).await;
+                if matches!(env.command, OrchestratorCommand::Stop) {
+                    state.stop.store(true, Ordering::Relaxed);
+                    let _ = ack_tx
+                        .send(DriverMessage::Deregister(DeregisterRequest { driver_id }))
+                        .await;
+                    break;
+                }
+            }
+            OrchestratorResponse::Ack(_) => {
+                // Heartbeat ack — nothing to do beyond confirming the loop is alive.
+            }
+            OrchestratorResponse::Error(e) => {
+                eprintln!(
+                    "arcane-swarm(orchestrated): orchestrator error: {}",
+                    e.message
+                );
+            }
+            OrchestratorResponse::RegisterRejected(_) => {
+                // Should not arrive after a successful register.
+            }
+        }
+    }
+
+    state.stop.store(true, Ordering::Relaxed);
+    let _ = writer.await;
+    eprintln!("arcane-swarm(orchestrated): exiting");
+    Ok(())
+}
+
+fn apply_command(state: &OrchestratedState, env: &CommandEnvelope) {
+    match &env.command {
+        OrchestratorCommand::SetPlayers(c) => {
+            state
+                .target_players
+                .store(c.player_count, Ordering::Relaxed);
+        }
+        OrchestratorCommand::SetSpawnDelayMs(c) => {
+            state
+                .spawn_delay_ms
+                .store(c.spawn_delay_ms, Ordering::Relaxed);
+        }
+        OrchestratorCommand::Stop => {
+            // stop bit is set by caller after the ack is enqueued
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arcane_swarm_orchestrator::protocol::{SetPlayersCommand, SetSpawnDelayMsCommand};
+
+    #[test]
+    fn apply_set_players_updates_atomic() {
+        let s = OrchestratedState::new(0, 0);
+        apply_command(
+            &s,
+            &CommandEnvelope {
+                seq: 1,
+                command: OrchestratorCommand::SetPlayers(SetPlayersCommand { player_count: 250 }),
+            },
+        );
+        assert_eq!(s.target_players.load(Ordering::Relaxed), 250);
+        assert_eq!(s.spawn_delay_ms.load(Ordering::Relaxed), 0);
+        assert!(!s.stop.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn apply_set_spawn_delay_updates_atomic() {
+        let s = OrchestratedState::new(100, 0);
+        apply_command(
+            &s,
+            &CommandEnvelope {
+                seq: 2,
+                command: OrchestratorCommand::SetSpawnDelayMs(SetSpawnDelayMsCommand {
+                    spawn_delay_ms: 250,
+                }),
+            },
+        );
+        assert_eq!(s.spawn_delay_ms.load(Ordering::Relaxed), 250);
+        assert_eq!(s.target_players.load(Ordering::Relaxed), 100);
+    }
+}

--- a/crates/arcane-swarm/tests/orchestrated_mode_e2e.rs
+++ b/crates/arcane-swarm/tests/orchestrated_mode_e2e.rs
@@ -1,0 +1,132 @@
+//! End-to-end test for the driver's orchestrated mode (#27): spin up a
+//! real `DriverServer` (with a real `CommandDispatcher`) and run the
+//! driver-side `run_orchestrated_mode` against it. Submit a SetPlayers
+//! command from the dispatcher and verify the driver:
+//!   - registered, getting back a driver_id
+//!   - received the command and updated its OrchestratedState
+//!   - acked the command, completing the dispatcher's submit()
+//!
+//! This complements the orchestrator-side e2e test in the orchestrator
+//! crate (which uses a synthetic driver client). Together they prove the
+//! full bidirectional wire path works.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use arcane_swarm::config::{Backend, SwarmMode};
+use arcane_swarm::orchestrated_mode::run_orchestrated_mode;
+use arcane_swarm::{BurstConfig, Config};
+use arcane_swarm_orchestrator::command_dispatcher::CommandDispatcher;
+use arcane_swarm_orchestrator::driver_pool::DriverPool;
+use arcane_swarm_orchestrator::protocol::{OrchestratorCommand, SetPlayersCommand};
+use arcane_swarm_orchestrator::server::handle_connection;
+use arcane_swarm_orchestrator::ws_driver_channel::WsDriverChannel;
+
+fn test_config(orchestrator_url: String) -> Config {
+    Config {
+        backend: Backend::Arcane,
+        spacetimedb_uri: "http://127.0.0.1:3000".into(),
+        database: "arcane".into(),
+        arcane_ws: "ws://127.0.0.1:8080".into(),
+        arcane_manager: None,
+        players: 100,
+        max_players: 1000,
+        tick_rate: 20,
+        duration_secs: 60,
+        mode: SwarmMode::Spread,
+        csv_path: None,
+        cluster_command: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        actions_per_sec: 0.0,
+        read_rate: 5.0,
+        server_physics: false,
+        run_forever: false,
+        control_port: 0,
+        burst: BurstConfig::default(),
+        user_data_bytes: 0,
+        inter_spawn_delay_ms: 0,
+        max_players_per_driver: 0,
+        orchestrator_url: Some(orchestrator_url),
+    }
+}
+
+#[tokio::test]
+async fn driver_registers_and_acks_commands_against_real_orchestrator() {
+    // Spin up the orchestrator's WS server with a real dispatcher.
+    let pool = Arc::new(DriverPool::new(
+        Duration::from_millis(100),
+        Duration::from_secs(2),
+        16,
+    ));
+    let dispatcher = Arc::new(CommandDispatcher::<WsDriverChannel>::new(pool.clone()));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("ws://{}", addr);
+
+    let pool_for_server = pool.clone();
+    let dispatcher_for_server = dispatcher.clone();
+    let _server = tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                return;
+            };
+            let pool = pool_for_server.clone();
+            let dispatcher = dispatcher_for_server.clone();
+            tokio::spawn(async move {
+                let _ = handle_connection(stream, pool, Some(dispatcher)).await;
+            });
+        }
+    });
+
+    // Run the driver in orchestrated mode in the background.
+    let cfg = test_config(url.clone());
+    let driver_handle = tokio::spawn(async move { run_orchestrated_mode(cfg).await });
+
+    // Wait until the driver registers (DriverPool size grows from 0 → 1).
+    for _ in 0..100 {
+        if pool.len().await >= 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(pool.len().await, 1, "driver should have registered");
+
+    // Submit a real command. The driver-side run loop should apply it and
+    // ack so this resolves.
+    let result = dispatcher
+        .submit(
+            "test-controller".to_string(),
+            OrchestratorCommand::SetPlayers(SetPlayersCommand { player_count: 250 }),
+        )
+        .await
+        .expect("dispatcher submit");
+    assert_eq!(
+        result.acks.len(),
+        1,
+        "driver should ack the SetPlayers command"
+    );
+    assert_eq!(result.acks[0].command_seq, result.seq);
+    assert!(result.missing.is_empty());
+
+    // Submit Stop to let the driver tear down cleanly.
+    let _ = dispatcher
+        .submit("test-controller".to_string(), OrchestratorCommand::Stop)
+        .await;
+
+    // Driver should exit on Stop.
+    match tokio::time::timeout(Duration::from_secs(3), driver_handle).await {
+        Ok(join_result) => {
+            let inner = join_result.expect("driver task join");
+            assert!(inner.is_ok(), "driver returned error: {:?}", inner);
+        }
+        Err(_) => panic!("driver did not exit after Stop within 3s"),
+    }
+}
+
+#[tokio::test]
+async fn driver_returns_error_when_orchestrator_unreachable() {
+    // Use a port that nothing is listening on.
+    let cfg = test_config("ws://127.0.0.1:1".into());
+    let result = run_orchestrated_mode(cfg).await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Closes [#27](https://github.com/brainy-bots/arcane_swarm/issues/27).

Adds \`--orchestrator-url\` to the existing \`arcane-swarm\` driver binary. When set, the driver switches from standalone mode to orchestrated mode: connects to a swarm orchestrator over WebSocket, registers, runs a heartbeat loop, and applies real-time \`SetPlayers\` / \`SetSpawnDelayMs\` / \`Stop\` commands by updating shared atomics and acking each with the orchestrator-assigned command seq.

**Standalone mode (no \`--orchestrator-url\`) is unchanged** — same FINAL line shape, same per-player loop wiring, same CLI semantics.

## Layout

- **\`src/orchestrated_mode.rs\`** (new, lives in lib so integration tests can drive it directly): \`OrchestratedState\` + \`run_orchestrated_mode\`
- **\`src/config.rs\`**: \`--orchestrator-url\` flag + \`ORCHESTRATOR_URL\` env, new \`Config.orchestrator_url\` field
- **\`src/bin/arcane_swarm/main.rs\`**: branches into \`orchestrated_mode\` before the existing run-forever / control-port branch
- **\`Cargo.toml\`**: \`arcane-swarm-orchestrator\` added as path dep so the driver shares the wire types

## Tests

- \`src/orchestrated_mode.rs\` unit tests cover \`apply_command\` for \`SetPlayers\` and \`SetSpawnDelayMs\` (state mutation correctness)
- \`tests/orchestrated_mode_e2e.rs\` spins up a real orchestrator (\`DriverServer\` + \`CommandDispatcher\`) on a random local port and runs the driver against it: verifies registration, command receipt + ack, and clean shutdown on \`Stop\`. Also asserts the driver returns an error when the orchestrator is unreachable.

## Out of scope (deliberate follow-up)

Wiring the \`OrchestratedState\` atomics (\`target_players\`, \`spawn_delay_ms\`) into the existing player-spawning machinery so \`SetPlayers\` actually drives a fleet ramp. The state is updated and acked correctly today; the spawn-loop integration is its own change because it needs to share a player-slot vector with the existing \`run_control_mode\` infrastructure.

## Test plan

- [x] \`cargo test -p arcane-swarm\` — 19 passed (4 unit incl. 2 new + 0 ignored, plus 2 e2e + 13 doc)
- [x] \`cargo test -p arcane-swarm-orchestrator\` — 58 passed (regression check on protocol changes from PR #49)
- [x] \`cargo build -p arcane-swarm\` clean
- [x] \`cargo clippy -p arcane-swarm --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)