### PR TITLE
feat(orchestrator): add arcane-swarm-orchestrator binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,7 @@ name = "arcane-swarm-orchestrator"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -266,6 +267,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -772,8 +779,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -783,9 +792,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -978,6 +989,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1305,6 +1317,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1598,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,6 +1834,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1768,6 +1843,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1775,6 +1851,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1790,6 +1867,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1820,6 +1903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1832,6 +1916,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3009,6 +3094,25 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/crates/arcane-swarm-orchestrator/Cargo.toml
+++ b/crates/arcane-swarm-orchestrator/Cargo.toml
@@ -5,10 +5,15 @@ edition = "2021"
 description = "Orchestrator for coordinating swarm benchmarks across distributed drivers."
 license = "AGPL-3.0-only"
 
+[[bin]]
+name = "arcane-swarm-orchestrator"
+path = "src/bin/orchestrator.rs"
+
 [dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "net", "time", "fs", "io-util"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "net", "time", "fs", "io-util", "signal"] }
 tokio-tungstenite = "0.21"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1", features = ["v4", "serde"] }
 futures = "0.3"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }

--- a/crates/arcane-swarm-orchestrator/src/bin/orchestrator.rs
+++ b/crates/arcane-swarm-orchestrator/src/bin/orchestrator.rs
@@ -1,0 +1,242 @@
+//! Orchestrator binary entry point.
+//!
+//! Brings up the full orchestrator process:
+//!   - DriverServer (WebSocket on --driver-port, default 8088)
+//!   - HTTP API (telemetry SSE + command submission, on --http-port,
+//!     default 8090)
+//!   - StatsCollector (polls each --cluster-stats-url every 2s)
+//!   - TelemetrySource (rolls a snapshot every --telemetry-interval-ms,
+//!     default 2000)
+//!   - TelemetryArchive (writes JSON snapshots under --archive-dir;
+//!     S3 upload deferred until aws-sdk dep lands)
+//!
+//! All ports bind on 0.0.0.0 so EC2 security groups (not the binary)
+//! gate access.
+//!
+//! Usage:
+//!   arcane-swarm-orchestrator \
+//!     --driver-port 8088 \
+//!     --http-port 8090 \
+//!     --cluster-stats-url http://cluster1:8091/stats \
+//!     --cluster-stats-url http://cluster2:8091/stats \
+//!     --archive-dir /var/orchestrator/snapshots
+
+use arcane_swarm_orchestrator::command_dispatcher::CommandDispatcher;
+use arcane_swarm_orchestrator::driver_pool::DriverPool;
+use arcane_swarm_orchestrator::server::DriverServer;
+use arcane_swarm_orchestrator::sse_server::serve;
+use arcane_swarm_orchestrator::stats_collector::{ClusterEndpoint, ClusterStats, StatsCollector};
+use arcane_swarm_orchestrator::telemetry::TelemetrySource;
+use arcane_swarm_orchestrator::telemetry_archive::{NoopUploader, TelemetryArchive};
+use arcane_swarm_orchestrator::ws_driver_channel::WsDriverChannel;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+struct HttpClusterEndpoint {
+    url: String,
+    http: reqwest::Client,
+}
+
+impl HttpClusterEndpoint {
+    fn new(url: String) -> Self {
+        Self {
+            url,
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(2))
+                .build()
+                .expect("reqwest client"),
+        }
+    }
+}
+
+impl ClusterEndpoint for HttpClusterEndpoint {
+    fn url(&self) -> &str {
+        &self.url
+    }
+    async fn fetch(&self) -> Result<ClusterStats, String> {
+        let resp = self
+            .http
+            .get(&self.url)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+        let status = resp.status();
+        let body = resp.text().await.map_err(|e| e.to_string())?;
+        if !status.is_success() {
+            return Err(format!("{}: {}", status, body));
+        }
+        // Parse a permissive subset of the cluster's /stats JSON. Unknown
+        // fields are ignored so the orchestrator stays compatible with
+        // future cluster-side schema additions.
+        let v: serde_json::Value = serde_json::from_str(&body).map_err(|e| e.to_string())?;
+        Ok(ClusterStats {
+            bytes_in: v["bytes_in"].as_u64().unwrap_or(0),
+            bytes_out: v["bytes_out"].as_u64().unwrap_or(0),
+            last_tick_us: v["last_tick_us"].as_u64().unwrap_or(0),
+            broadcast_lagged_events: v["broadcast_lagged_events"].as_u64().unwrap_or(0),
+            entities_current: v["entities_current"].as_u64().unwrap_or(0),
+            sampled_at: Instant::now(),
+        })
+    }
+}
+
+#[derive(Default)]
+struct Args {
+    driver_port: u16,
+    http_port: u16,
+    cluster_stats_urls: Vec<String>,
+    archive_dir: Option<String>,
+    telemetry_interval_ms: u64,
+    max_drivers: usize,
+}
+
+fn parse_args() -> Args {
+    let mut a = Args {
+        driver_port: 8088,
+        http_port: 8090,
+        cluster_stats_urls: Vec::new(),
+        archive_dir: None,
+        telemetry_interval_ms: 2_000,
+        max_drivers: 64,
+    };
+    let argv: Vec<String> = std::env::args().collect();
+    let mut i = 1;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--driver-port" => {
+                i += 1;
+                a.driver_port = argv[i].parse().expect("--driver-port");
+            }
+            "--http-port" => {
+                i += 1;
+                a.http_port = argv[i].parse().expect("--http-port");
+            }
+            "--cluster-stats-url" => {
+                i += 1;
+                a.cluster_stats_urls.push(argv[i].clone());
+            }
+            "--archive-dir" => {
+                i += 1;
+                a.archive_dir = Some(argv[i].clone());
+            }
+            "--telemetry-interval-ms" => {
+                i += 1;
+                a.telemetry_interval_ms = argv[i].parse().expect("--telemetry-interval-ms");
+            }
+            "--max-drivers" => {
+                i += 1;
+                a.max_drivers = argv[i].parse().expect("--max-drivers");
+            }
+            "-h" | "--help" => {
+                eprintln!(
+                    "usage: arcane-swarm-orchestrator [--driver-port N] [--http-port N] \
+                     [--cluster-stats-url URL]... [--archive-dir DIR] \
+                     [--telemetry-interval-ms N] [--max-drivers N]"
+                );
+                std::process::exit(0);
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    a
+}
+
+#[tokio::main]
+async fn main() {
+    let args = parse_args();
+
+    eprintln!(
+        "arcane-swarm-orchestrator: driver_port={} http_port={} clusters={} archive_dir={:?} telemetry_interval_ms={}",
+        args.driver_port,
+        args.http_port,
+        args.cluster_stats_urls.len(),
+        args.archive_dir,
+        args.telemetry_interval_ms,
+    );
+
+    let pool = Arc::new(DriverPool::new(
+        Duration::from_secs(5),
+        Duration::from_secs(15),
+        args.max_drivers,
+    ));
+    let dispatcher = Arc::new(CommandDispatcher::<WsDriverChannel>::new(pool.clone()));
+
+    let endpoints: Vec<Arc<HttpClusterEndpoint>> = args
+        .cluster_stats_urls
+        .into_iter()
+        .map(|u| Arc::new(HttpClusterEndpoint::new(u)))
+        .collect();
+    let collector = Arc::new(StatsCollector::new(endpoints));
+
+    let source = Arc::new(TelemetrySource::new(
+        pool.clone(),
+        dispatcher.clone(),
+        collector.clone(),
+    ));
+
+    // Spawn the stats collector loop.
+    {
+        let collector = collector.clone();
+        tokio::spawn(async move {
+            let _ = collector.run().await;
+        });
+    }
+
+    // Spawn the telemetry tick loop.
+    {
+        let source = source.clone();
+        let interval = Duration::from_millis(args.telemetry_interval_ms);
+        tokio::spawn(async move {
+            source.run(interval).await;
+        });
+    }
+
+    // Spawn the telemetry archive (local-only for now; S3 follow-up).
+    if let Some(dir) = args.archive_dir.clone() {
+        let source = source.clone();
+        tokio::spawn(async move {
+            let archive = TelemetryArchive::new(dir, Arc::new(NoopUploader));
+            let rx = source.subscribe();
+            let _ = archive.run(rx).await;
+        });
+    }
+
+    // Spawn the HTTP API server (telemetry SSE + command submission).
+    let http_addr: SocketAddr = format!("0.0.0.0:{}", args.http_port)
+        .parse()
+        .expect("http addr");
+    {
+        let source = source.clone();
+        let dispatcher = dispatcher.clone();
+        tokio::spawn(async move {
+            let _ = serve(http_addr, source, Some(dispatcher)).await;
+        });
+    }
+    eprintln!(
+        "arcane-swarm-orchestrator: HTTP API listening on {}",
+        http_addr
+    );
+
+    // Run the driver WS server in the foreground (blocks until shutdown).
+    let driver_addr: SocketAddr = format!("0.0.0.0:{}", args.driver_port)
+        .parse()
+        .expect("driver addr");
+    eprintln!(
+        "arcane-swarm-orchestrator: driver WS listening on {}",
+        driver_addr
+    );
+    let server = DriverServer::with_dispatcher(pool, dispatcher);
+
+    tokio::select! {
+        res = server.listen(driver_addr) => {
+            if let Err(e) = res {
+                eprintln!("driver server error: {}", e);
+            }
+        }
+        _ = tokio::signal::ctrl_c() => {
+            eprintln!("arcane-swarm-orchestrator: shutting down on SIGINT");
+        }
+    }
+}


### PR DESCRIPTION
Adds the runnable orchestrator binary needed for AWS deployment. The crate was a library only; this wraps DriverServer + HTTP API + StatsCollector + TelemetrySource + TelemetryArchive into a single command-line process.

```
arcane-swarm-orchestrator \
  --driver-port 8088 \
  --http-port 8090 \
  --cluster-stats-url http://cluster1:8091/stats \
  --archive-dir /var/orchestrator/snapshots
```

All 61 existing tests still pass. clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)