### PR TITLE
feat(orchestrator+driver): per-driver player distribution + spawn-loop wiring

### DIFF
--- a/crates/arcane-swarm-orchestrator/src/command_dispatcher.rs
+++ b/crates/arcane-swarm-orchestrator/src/command_dispatcher.rs
@@ -11,7 +11,7 @@
 //! and replies with scripted acks.
 
 use crate::driver_pool::{DriverPool, DriverState};
-use crate::protocol::{CommandAck, DriverId, OrchestratorCommand};
+use crate::protocol::{CommandAck, DriverId, OrchestratorCommand, SetPlayersCommand};
 use std::collections::HashMap;
 use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -128,12 +128,47 @@ impl<C: DriverChannel + 'static> CommandDispatcher<C> {
         }
 
         // Snapshot per-driver channels under the read lock, then drop it.
-        let channels: HashMap<DriverId, Arc<C>> = {
+        // Sort by DriverId so the per-driver distribution below is
+        // deterministic — without this, the remainder allocation for
+        // SetPlayers would jitter across calls.
+        let mut active_with_channels: Vec<(DriverId, Arc<C>)> = {
             let map = self.channels.read().await;
             active
                 .iter()
                 .filter_map(|id| map.get(id).map(|ch| (*id, Arc::clone(ch))))
                 .collect()
+        };
+        active_with_channels.sort_by_key(|(id, _)| *id);
+
+        // For SetPlayers, the orchestrator OWNS the per-driver allocation.
+        // The controller submits an AGGREGATE target; the orchestrator
+        // divides it across the active drivers (with the remainder spread
+        // across the first `rem` drivers so the sum exactly equals the
+        // submitted target). All other commands broadcast unchanged.
+        let per_driver_commands: Vec<(DriverId, Arc<C>, OrchestratorCommand)> = match &command {
+            OrchestratorCommand::SetPlayers(set) => {
+                let k = active_with_channels.len() as u32;
+                let base = set.player_count.checked_div(k).unwrap_or(0);
+                let rem = set.player_count.checked_rem(k).unwrap_or(0);
+                active_with_channels
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, (id, ch))| {
+                        let per = base + if (i as u32) < rem { 1 } else { 0 };
+                        (
+                            id,
+                            ch,
+                            OrchestratorCommand::SetPlayers(SetPlayersCommand {
+                                player_count: per,
+                            }),
+                        )
+                    })
+                    .collect()
+            }
+            _ => active_with_channels
+                .into_iter()
+                .map(|(id, ch)| (id, ch, command.clone()))
+                .collect(),
         };
 
         // Fan out. Each task pushes its (driver_id, result) onto a shared
@@ -141,10 +176,9 @@ impl<C: DriverChannel + 'static> CommandDispatcher<C> {
         // every task reports or the fan-out deadline elapses. Cancellation
         // of slow tasks is implicit — they remain spawned but their results
         // are ignored once we move past the deadline.
-        let n = channels.len();
+        let n = per_driver_commands.len();
         let (tx, mut rx) = mpsc::channel(n.max(1));
-        for (driver_id, ch) in channels {
-            let cmd = command.clone();
+        for (driver_id, ch, cmd) in per_driver_commands {
             let tx = tx.clone();
             tokio::spawn(async move {
                 let result = ch.send(seq, cmd).await;

--- a/crates/arcane-swarm-orchestrator/src/tests/command_dispatch.rs
+++ b/crates/arcane-swarm-orchestrator/src/tests/command_dispatch.rs
@@ -113,11 +113,25 @@ async fn set_players_broadcasts_to_all_active_drivers_within_100ms() {
     );
     assert_eq!(result.acks.len(), 12, "all 12 drivers should ack");
     assert!(result.missing.is_empty(), "no driver should be missing");
+    // Per-driver distribution: 125 / 12 = 10 base, rem = 5; first 5 drivers
+    // get 11, rest get 10. Sum = 5*11 + 7*10 = 125.
+    let mut counts: Vec<u32> = Vec::new();
     for ch in channels.values() {
         let sent = ch.sent_commands().await;
         assert_eq!(sent.len(), 1);
-        assert_eq!(sent[0], cmd);
+        if let OrchestratorCommand::SetPlayers(s) = &sent[0] {
+            counts.push(s.player_count);
+        } else {
+            panic!("expected SetPlayers; got {:?}", sent[0]);
+        }
     }
+    counts.sort();
+    assert_eq!(
+        counts.iter().sum::<u32>(),
+        125,
+        "per-driver counts sum to aggregate"
+    );
+    let _ = cmd;
 }
 
 #[tokio::test]
@@ -279,6 +293,90 @@ async fn stop_command_is_broadcast_and_logged() {
     let log = dispatcher.command_log().await;
     assert_eq!(log.len(), 1);
     assert!(matches!(log[0].command, OrchestratorCommand::Stop));
+}
+
+#[tokio::test]
+async fn set_players_is_distributed_per_driver_evenly() {
+    // 4 drivers, target 100 → each driver gets 25.
+    let (dispatcher, _pool, channels) = fleet(4).await;
+    let _ = dispatcher
+        .submit(
+            "controller-a".to_string(),
+            OrchestratorCommand::SetPlayers(SetPlayersCommand { player_count: 100 }),
+        )
+        .await
+        .unwrap();
+    for ch in channels.values() {
+        let sent = ch.sent_commands().await;
+        assert_eq!(sent.len(), 1);
+        match &sent[0] {
+            OrchestratorCommand::SetPlayers(s) => assert_eq!(s.player_count, 25),
+            _ => panic!("expected SetPlayers"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn set_players_distributes_remainder_to_first_drivers() {
+    // 4 drivers, target 102 → first 2 get 26, last 2 get 25 (sum = 102).
+    let (dispatcher, _pool, channels) = fleet(4).await;
+    let _ = dispatcher
+        .submit(
+            "controller-a".to_string(),
+            OrchestratorCommand::SetPlayers(SetPlayersCommand { player_count: 102 }),
+        )
+        .await
+        .unwrap();
+    let mut counts: Vec<u32> = Vec::new();
+    for ch in channels.values() {
+        let sent = ch.sent_commands().await;
+        if let OrchestratorCommand::SetPlayers(s) = &sent[0] {
+            counts.push(s.player_count);
+        }
+    }
+    counts.sort();
+    assert_eq!(counts, vec![25, 25, 26, 26]);
+    assert_eq!(counts.iter().sum::<u32>(), 102);
+}
+
+#[tokio::test]
+async fn set_players_aggregate_13500_across_12_drivers_is_1125_each() {
+    // Headline scenario: 13,500 aggregate / 12 drivers = 1,125 each, exact.
+    let (dispatcher, _pool, channels) = fleet(12).await;
+    let _ = dispatcher
+        .submit(
+            "controller-a".to_string(),
+            OrchestratorCommand::SetPlayers(SetPlayersCommand {
+                player_count: 13_500,
+            }),
+        )
+        .await
+        .unwrap();
+    for ch in channels.values() {
+        let sent = ch.sent_commands().await;
+        if let OrchestratorCommand::SetPlayers(s) = &sent[0] {
+            assert_eq!(s.player_count, 1_125);
+        }
+    }
+}
+
+#[tokio::test]
+async fn set_spawn_delay_ms_remains_a_broadcast() {
+    // Non-SetPlayers commands go to every driver verbatim.
+    let (dispatcher, _pool, channels) = fleet(4).await;
+    let _ = dispatcher
+        .submit(
+            "controller-a".to_string(),
+            OrchestratorCommand::SetSpawnDelayMs(SetSpawnDelayMsCommand { spawn_delay_ms: 50 }),
+        )
+        .await
+        .unwrap();
+    for ch in channels.values() {
+        let sent = ch.sent_commands().await;
+        if let OrchestratorCommand::SetSpawnDelayMs(s) = &sent[0] {
+            assert_eq!(s.spawn_delay_ms, 50);
+        }
+    }
 }
 
 #[tokio::test]

--- a/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
@@ -605,10 +605,37 @@ async fn main() {
     let backend_name = backend_runtime.name();
 
     if cfg.orchestrator_url.is_some() {
-        if let Err(e) = orchestrated_mode::run_orchestrated_mode(cfg).await {
-            eprintln!("arcane-swarm(orchestrated): {}", e);
-            std::process::exit(1);
-        }
+        // Orchestrated mode: pick a free localhost port for the control
+        // bridge, run the standard control-mode spawn loop on it, and
+        // bridge inbound orchestrator commands (SetPlayers, Stop) into the
+        // existing TCP control protocol so real players actually spawn.
+        let bridge_port = orchestrated_mode::pick_free_local_port()
+            .await
+            .expect("pick free local port for orchestrated bridge");
+        let mut cfg_for_control = cfg.clone();
+        cfg_for_control.control_port = bridge_port;
+        cfg_for_control.run_forever = true;
+        // Initial player count of 0 — the bridge will push the actual
+        // initial value via SET_PLAYERS once it's connected to the
+        // orchestrator. Without this, the spawn loop would burst the
+        // initial cfg.players up before any orchestrator command lands.
+        cfg_for_control.players = 0;
+
+        let cfg_for_bridge = cfg.clone();
+        let state =
+            orchestrated_mode::OrchestratedState::new(cfg.players, cfg.inter_spawn_delay_ms);
+        let bridge_state = state.clone();
+        let bridge = tokio::spawn(async move {
+            if let Err(e) =
+                orchestrated_mode::run_ws_to_tcp_bridge(cfg_for_bridge, bridge_port, bridge_state)
+                    .await
+            {
+                eprintln!("arcane-swarm(orchestrated bridge): {}", e);
+            }
+        });
+
+        run_control_mode(cfg_for_control, tick_interval).await;
+        let _ = bridge.await;
         return;
     }
 

--- a/crates/arcane-swarm/src/orchestrated_mode.rs
+++ b/crates/arcane-swarm/src/orchestrated_mode.rs
@@ -1,17 +1,16 @@
 //! Orchestrated mode for the swarm driver.
 //!
-//! When the operator passes `--orchestrator-url <url>`, the driver connects
-//! to a swarm orchestrator over WebSocket, registers, sends periodic
-//! heartbeats, and applies real-time commands (`SetPlayers`, `SetSpawnDelayMs`,
-//! `Stop`) by updating shared atomics. Each command is acknowledged with a
-//! `CommandAck` carrying the orchestrator-assigned sequence number.
-//!
-//! **Scope of this module.** This is the wire-protocol half of the driver
-//! protocol extension (#27). It maintains the `target_players` and
-//! `spawn_delay_ms` state mutated by orchestrator commands, but does **not**
-//! drive the existing per-player spawning machinery — wiring that state into
-//! the live spawn loop is a follow-up. The contract this PR satisfies:
-//! "registration succeeds, commands received, telemetry pushed."
+//! When the operator passes `--orchestrator-url <url>`, the driver:
+//!   1. Picks a free localhost TCP port for the control bridge.
+//!   2. Starts the standard `run_control_mode` loop (in main) listening on
+//!      that port — same well-tested player spawn / metrics / FINAL-line
+//!      machinery the SSM-driven harness uses.
+//!   3. Connects to the swarm orchestrator over WebSocket, registers,
+//!      sends periodic heartbeats.
+//!   4. On each inbound `OrchestratorCommand`, translates it to the
+//!      local control protocol (`SET_PLAYERS N`, `QUIT`) and acks back to
+//!      the orchestrator. This makes the orchestrator's `SetPlayers(N)`
+//!      actually drive real player spawning via the existing control path.
 //!
 //! Standalone mode (no `--orchestrator-url`) is unchanged.
 
@@ -25,11 +24,13 @@ use serde_json::json;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+use tokio::net::{TcpListener, TcpStream};
 use tokio::time;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
-/// Shared state mutated by orchestrator commands. Public so a future PR
-/// (driving the existing spawn loop from these atomics) can read them.
+/// Shared state mutated by orchestrator commands. Public so observers (e.g.
+/// future telemetry hooks) can read the current target without taking a lock.
 #[derive(Clone)]
 pub struct OrchestratedState {
     pub target_players: Arc<AtomicU32>,
@@ -47,19 +48,60 @@ impl OrchestratedState {
     }
 }
 
-/// Connect, register, run the heartbeat + command loop until either the
-/// orchestrator disconnects or a `Stop` command is received.
-pub async fn run_orchestrated_mode(cfg: Config) -> Result<(), String> {
+/// Pick a free localhost TCP port by binding 0.0.0.0:0 and reading back
+/// the kernel-assigned port. The listener is dropped before returning so
+/// the caller (run_control_mode) can re-bind it.
+pub async fn pick_free_local_port() -> std::io::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(port)
+}
+
+/// Wait until something is accepting TCP on `127.0.0.1:port`. Used to
+/// synchronize the orchestrator-WS task with the control-mode TCP server
+/// startup; without it the bridge can connect before run_control_mode has
+/// bound its listener.
+async fn wait_for_local_tcp(port: u16, timeout: Duration) -> Result<(), String> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if std::time::Instant::now() >= deadline {
+            return Err(format!("control port {} did not bind in time", port));
+        }
+        if TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+            return Ok(());
+        }
+        time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Connect to the orchestrator, register, then bridge inbound commands to
+/// the local control-mode TCP server. Runs until either `Stop` is received
+/// or the WS/TCP connection drops. The caller is expected to also be
+/// running `run_control_mode` (or equivalent) on `tcp_port`.
+pub async fn run_ws_to_tcp_bridge(
+    cfg: Config,
+    tcp_port: u16,
+    state: OrchestratedState,
+) -> Result<(), String> {
     let url = cfg
         .orchestrator_url
         .clone()
-        .expect("run_orchestrated_mode requires --orchestrator-url");
+        .expect("run_ws_to_tcp_bridge requires --orchestrator-url");
 
     eprintln!(
-        "arcane-swarm(orchestrated): connecting to {} (initial players={}, spawn_delay_ms={})",
-        url, cfg.players, cfg.inter_spawn_delay_ms
+        "arcane-swarm(orchestrated): connecting to {} (initial players={}, spawn_delay_ms={}, control_bridge=127.0.0.1:{})",
+        url, cfg.players, cfg.inter_spawn_delay_ms, tcp_port
     );
 
+    // Wait for run_control_mode's TCP server to bind so the first
+    // SET_PLAYERS doesn't race ahead of the listener.
+    wait_for_local_tcp(tcp_port, Duration::from_secs(15)).await?;
+    let mut tcp = TcpStream::connect(("127.0.0.1", tcp_port))
+        .await
+        .map_err(|e| format!("connect to local control port: {}", e))?;
+
+    // Connect + register against the orchestrator.
     let (ws, _) = connect_async(&url).await.map_err(|e| e.to_string())?;
     let (mut sender, mut receiver) = ws.split();
 
@@ -102,10 +144,16 @@ pub async fn run_orchestrated_mode(cfg: Config) -> Result<(), String> {
     };
     eprintln!("arcane-swarm(orchestrated): registered as {}", driver_id);
 
-    let state = OrchestratedState::new(cfg.players, cfg.inter_spawn_delay_ms);
+    // Push the driver's initial player count straight into the control
+    // server so the operator's --players starting count actually becomes
+    // the initial spawn target. Otherwise run_control_mode starts at 0
+    // until the first SetPlayers arrives over WS.
+    let _ = tcp
+        .write_all(format!("SET_PLAYERS {}\n", cfg.players).as_bytes())
+        .await;
 
-    // Heartbeat task. Independent of the read loop so missed heartbeats are
-    // determined by wall-clock cadence, not message arrival rate.
+    // Heartbeat task — independent of the read loop so missed heartbeats
+    // are determined by wall-clock, not message arrival rate.
     let (hb_tx, mut hb_rx) = tokio::sync::mpsc::channel::<DriverMessage>(8);
     let hb_state_stop = state.stop.clone();
     tokio::spawn(async move {
@@ -125,8 +173,7 @@ pub async fn run_orchestrated_mode(cfg: Config) -> Result<(), String> {
         }
     });
 
-    // Outbound multiplexer: writes Heartbeat (from hb_rx) + CommandAck (from
-    // ack_tx) onto the single WS sink.
+    // Outbound multiplexer — heartbeats + acks share the WS sink.
     let (ack_tx, mut ack_rx) = tokio::sync::mpsc::channel::<DriverMessage>(64);
     let writer_stop = state.stop.clone();
     let writer = tokio::spawn(async move {
@@ -158,7 +205,8 @@ pub async fn run_orchestrated_mode(cfg: Config) -> Result<(), String> {
         }
     });
 
-    // Read loop: process orchestrator-pushed messages.
+    // Read loop: process orchestrator-pushed messages, translate to TCP
+    // control commands, ack back.
     while let Some(msg_result) = receiver.next().await {
         let msg = match msg_result {
             Ok(m) => m,
@@ -177,7 +225,12 @@ pub async fn run_orchestrated_mode(cfg: Config) -> Result<(), String> {
         };
         match resp {
             OrchestratorResponse::Command(env) => {
-                apply_command(&state, &env);
+                // Apply to the shared atomics first (observers / tests
+                // care) and then translate to the TCP control protocol the
+                // existing run_control_mode speaks.
+                if let Err(e) = apply_to_tcp(&state, &env, &mut tcp).await {
+                    eprintln!("arcane-swarm(orchestrated): TCP bridge write failed: {}", e);
+                }
                 let ack = DriverMessage::CommandAck(CommandAck {
                     driver_id,
                     command_seq: env.seq,
@@ -192,7 +245,7 @@ pub async fn run_orchestrated_mode(cfg: Config) -> Result<(), String> {
                 }
             }
             OrchestratorResponse::Ack(_) => {
-                // Heartbeat ack — nothing to do beyond confirming the loop is alive.
+                // Heartbeat ack — confirms the loop is alive.
             }
             OrchestratorResponse::Error(e) => {
                 eprintln!(
@@ -212,22 +265,49 @@ pub async fn run_orchestrated_mode(cfg: Config) -> Result<(), String> {
     Ok(())
 }
 
-fn apply_command(state: &OrchestratedState, env: &CommandEnvelope) {
+async fn apply_to_tcp(
+    state: &OrchestratedState,
+    env: &CommandEnvelope,
+    tcp: &mut TcpStream,
+) -> Result<(), String> {
     match &env.command {
         OrchestratorCommand::SetPlayers(c) => {
             state
                 .target_players
                 .store(c.player_count, Ordering::Relaxed);
+            tcp.write_all(format!("SET_PLAYERS {}\n", c.player_count).as_bytes())
+                .await
+                .map_err(|e| e.to_string())
         }
         OrchestratorCommand::SetSpawnDelayMs(c) => {
+            // run_control_mode reads inter_spawn_delay_ms once at startup
+            // (a static `Duration`). Updating it mid-run requires extending
+            // the TCP control protocol with SET_SPAWN_DELAY; until that
+            // lands the value here is recorded for observers but isn't
+            // applied to ongoing spawns. The headline benchmark sets a
+            // single spawn_delay_ms at the first phase, so this is fine
+            // for now.
             state
                 .spawn_delay_ms
                 .store(c.spawn_delay_ms, Ordering::Relaxed);
+            Ok(())
         }
         OrchestratorCommand::Stop => {
-            // stop bit is set by caller after the ack is enqueued
+            // Tell run_control_mode to drain + exit.
+            tcp.write_all(b"QUIT\n").await.map_err(|e| e.to_string())
         }
     }
+}
+
+/// Backward-compat entry that constructs default state and runs the
+/// bridge. Kept so existing tests + callers that don't share state with
+/// the spawn loop still compile.
+pub async fn run_orchestrated_mode(cfg: Config) -> Result<(), String> {
+    let state = OrchestratedState::new(cfg.players, cfg.inter_spawn_delay_ms);
+    let port = pick_free_local_port()
+        .await
+        .map_err(|e| format!("pick local port: {}", e))?;
+    run_ws_to_tcp_bridge(cfg, port, state).await
 }
 
 #[cfg(test)]
@@ -235,34 +315,115 @@ mod tests {
     use super::*;
     use arcane_swarm_orchestrator::protocol::{SetPlayersCommand, SetSpawnDelayMsCommand};
 
-    #[test]
-    fn apply_set_players_updates_atomic() {
+    #[tokio::test]
+    async fn pick_free_port_returns_distinct_unused_port() {
+        let p1 = pick_free_local_port().await.unwrap();
+        let p2 = pick_free_local_port().await.unwrap();
+        assert!(p1 > 1024);
+        assert!(p2 > 1024);
+        // Don't assert distinct — kernel may reuse — but bind both
+        // sequentially to confirm neither is in TIME_WAIT.
+        let _l = TcpListener::bind(("127.0.0.1", p1)).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn apply_to_tcp_writes_set_players_line() {
+        // Bind a listener, accept one connection in the background, capture
+        // the bytes the bridge writes.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let server = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 64];
+            use tokio::io::AsyncReadExt;
+            let n = sock.read(&mut buf).await.unwrap();
+            String::from_utf8_lossy(&buf[..n]).to_string()
+        });
+
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
         let s = OrchestratedState::new(0, 0);
-        apply_command(
+        apply_to_tcp(
             &s,
             &CommandEnvelope {
                 seq: 1,
                 command: OrchestratorCommand::SetPlayers(SetPlayersCommand { player_count: 250 }),
             },
-        );
+            &mut client,
+        )
+        .await
+        .unwrap();
+        drop(client);
+
+        let received = server.await.unwrap();
+        assert_eq!(received, "SET_PLAYERS 250\n");
         assert_eq!(s.target_players.load(Ordering::Relaxed), 250);
-        assert_eq!(s.spawn_delay_ms.load(Ordering::Relaxed), 0);
-        assert!(!s.stop.load(Ordering::Relaxed));
     }
 
-    #[test]
-    fn apply_set_spawn_delay_updates_atomic() {
-        let s = OrchestratedState::new(100, 0);
-        apply_command(
+    #[tokio::test]
+    async fn apply_to_tcp_translates_stop_to_quit() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            use tokio::io::AsyncReadExt;
+            let mut buf = [0u8; 16];
+            let n = sock.read(&mut buf).await.unwrap();
+            String::from_utf8_lossy(&buf[..n]).to_string()
+        });
+
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let s = OrchestratedState::new(0, 0);
+        apply_to_tcp(
             &s,
             &CommandEnvelope {
                 seq: 2,
+                command: OrchestratorCommand::Stop,
+            },
+            &mut client,
+        )
+        .await
+        .unwrap();
+        drop(client);
+        let received = server.await.unwrap();
+        assert_eq!(received, "QUIT\n");
+    }
+
+    #[tokio::test]
+    async fn apply_to_tcp_records_spawn_delay_locally() {
+        // SetSpawnDelayMs records the value in OrchestratedState but does
+        // not write to TCP (the existing control protocol has no
+        // SET_SPAWN_DELAY). This test pins that contract so a future
+        // protocol extension doesn't silently change behavior.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            use tokio::io::AsyncReadExt;
+            let mut buf = [0u8; 16];
+            let n = tokio::time::timeout(Duration::from_millis(200), sock.read(&mut buf))
+                .await
+                .map(|r| r.unwrap_or(0))
+                .unwrap_or(0);
+            String::from_utf8_lossy(&buf[..n]).to_string()
+        });
+        let mut client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let s = OrchestratedState::new(0, 0);
+        apply_to_tcp(
+            &s,
+            &CommandEnvelope {
+                seq: 3,
                 command: OrchestratorCommand::SetSpawnDelayMs(SetSpawnDelayMsCommand {
                     spawn_delay_ms: 250,
                 }),
             },
-        );
+            &mut client,
+        )
+        .await
+        .unwrap();
+        drop(client);
+        let received = server.await.unwrap();
+        assert_eq!(received, "");
         assert_eq!(s.spawn_delay_ms.load(Ordering::Relaxed), 250);
-        assert_eq!(s.target_players.load(Ordering::Relaxed), 100);
     }
 }

--- a/crates/arcane-swarm/tests/orchestrated_mode_e2e.rs
+++ b/crates/arcane-swarm/tests/orchestrated_mode_e2e.rs
@@ -1,26 +1,31 @@
-//! End-to-end test for the driver's orchestrated mode (#27): spin up a
-//! real `DriverServer` (with a real `CommandDispatcher`) and run the
-//! driver-side `run_orchestrated_mode` against it. Submit a SetPlayers
-//! command from the dispatcher and verify the driver:
-//!   - registered, getting back a driver_id
-//!   - received the command and updated its OrchestratedState
-//!   - acked the command, completing the dispatcher's submit()
+//! End-to-end test for the driver's orchestrated mode (#27).
 //!
-//! This complements the orchestrator-side e2e test in the orchestrator
-//! crate (which uses a synthetic driver client). Together they prove the
-//! full bidirectional wire path works.
-
-use std::sync::Arc;
-use std::time::Duration;
+//! Spins up a real orchestrator (DriverServer + CommandDispatcher) AND a
+//! stub TCP listener (standing in for the local control-mode server the
+//! real driver would run alongside the bridge), then runs
+//! `run_ws_to_tcp_bridge` and verifies that SetPlayers commands round-trip
+//! end-to-end:
+//!
+//!   controller → orchestrator → WS → driver bridge → local TCP → "SET_PLAYERS N"
+//!   driver bridge → CommandAck → orchestrator → controller
+//!
+//! The stub TCP listener captures every line the bridge writes so the test
+//! can assert the per-driver player count actually reached the control
+//! protocol.
 
 use arcane_swarm::config::{Backend, SwarmMode};
-use arcane_swarm::orchestrated_mode::run_orchestrated_mode;
+use arcane_swarm::orchestrated_mode::{run_ws_to_tcp_bridge, OrchestratedState};
 use arcane_swarm::{BurstConfig, Config};
 use arcane_swarm_orchestrator::command_dispatcher::CommandDispatcher;
 use arcane_swarm_orchestrator::driver_pool::DriverPool;
 use arcane_swarm_orchestrator::protocol::{OrchestratorCommand, SetPlayersCommand};
 use arcane_swarm_orchestrator::server::handle_connection;
 use arcane_swarm_orchestrator::ws_driver_channel::WsDriverChannel;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
 
 fn test_config(orchestrator_url: String) -> Config {
     Config {
@@ -50,7 +55,7 @@ fn test_config(orchestrator_url: String) -> Config {
 }
 
 #[tokio::test]
-async fn driver_registers_and_acks_commands_against_real_orchestrator() {
+async fn driver_bridge_relays_set_players_into_local_control_protocol() {
     // Spin up the orchestrator's WS server with a real dispatcher.
     let pool = Arc::new(DriverPool::new(
         Duration::from_millis(100),
@@ -59,13 +64,13 @@ async fn driver_registers_and_acks_commands_against_real_orchestrator() {
     ));
     let dispatcher = Arc::new(CommandDispatcher::<WsDriverChannel>::new(pool.clone()));
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let url = format!("ws://{}", addr);
 
     let pool_for_server = pool.clone();
     let dispatcher_for_server = dispatcher.clone();
-    let _server = tokio::spawn(async move {
+    tokio::spawn(async move {
         loop {
             let Ok((stream, _)) = listener.accept().await else {
                 return;
@@ -78,11 +83,40 @@ async fn driver_registers_and_acks_commands_against_real_orchestrator() {
         }
     });
 
-    // Run the driver in orchestrated mode in the background.
-    let cfg = test_config(url.clone());
-    let driver_handle = tokio::spawn(async move { run_orchestrated_mode(cfg).await });
+    // Stub local control listener — this is what run_control_mode would be
+    // doing in production. Accepts every connection (the bridge does a
+    // wait-for-listener probe before its real connection, so we need at
+    // least 2 accepts).
+    let stub_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let stub_port = stub_listener.local_addr().unwrap().port();
+    let captured_lines: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured_for_stub = captured_lines.clone();
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = stub_listener.accept().await else {
+                return;
+            };
+            let captured = captured_for_stub.clone();
+            tokio::spawn(async move {
+                let mut reader = BufReader::new(stream).lines();
+                while let Ok(Some(line)) = reader.next_line().await {
+                    captured.lock().await.push(line);
+                }
+            });
+        }
+    });
 
-    // Wait until the driver registers (DriverPool size grows from 0 → 1).
+    // Run the driver bridge against the orchestrator + stub listener.
+    let cfg = test_config(url.clone());
+    let state = OrchestratedState::new(cfg.players, cfg.inter_spawn_delay_ms);
+    let bridge_state = state.clone();
+    let bridge_cfg = cfg.clone();
+    let bridge_handle =
+        tokio::spawn(
+            async move { run_ws_to_tcp_bridge(bridge_cfg, stub_port, bridge_state).await },
+        );
+
+    // Wait for driver registration.
     for _ in 0..100 {
         if pool.len().await >= 1 {
             break;
@@ -91,8 +125,25 @@ async fn driver_registers_and_acks_commands_against_real_orchestrator() {
     }
     assert_eq!(pool.len().await, 1, "driver should have registered");
 
-    // Submit a real command. The driver-side run loop should apply it and
-    // ack so this resolves.
+    // Initial SET_PLAYERS from cfg.players (100) should land within a few hundred ms.
+    for _ in 0..50 {
+        if !captured_lines.lock().await.is_empty() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    {
+        let lines = captured_lines.lock().await;
+        assert!(
+            lines.iter().any(|l| l == "SET_PLAYERS 100"),
+            "initial SET_PLAYERS 100 should be written; got {:?}",
+            *lines
+        );
+    }
+
+    // Submit a SetPlayers from the controller side. The orchestrator
+    // distributes per-driver — with 1 driver, the per-driver count equals
+    // the aggregate.
     let result = dispatcher
         .submit(
             "test-controller".to_string(),
@@ -106,27 +157,82 @@ async fn driver_registers_and_acks_commands_against_real_orchestrator() {
         "driver should ack the SetPlayers command"
     );
     assert_eq!(result.acks[0].command_seq, result.seq);
-    assert!(result.missing.is_empty());
 
-    // Submit Stop to let the driver tear down cleanly.
+    // Wait for the SET_PLAYERS 250 line to arrive on the stub listener.
+    for _ in 0..50 {
+        let lines = captured_lines.lock().await;
+        if lines.iter().any(|l| l == "SET_PLAYERS 250") {
+            break;
+        }
+        drop(lines);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    {
+        let lines = captured_lines.lock().await;
+        assert!(
+            lines.iter().any(|l| l == "SET_PLAYERS 250"),
+            "SET_PLAYERS 250 should be written by the bridge; got {:?}",
+            *lines
+        );
+    }
+
+    // Submit Stop to drain the bridge cleanly.
     let _ = dispatcher
         .submit("test-controller".to_string(), OrchestratorCommand::Stop)
         .await;
 
-    // Driver should exit on Stop.
-    match tokio::time::timeout(Duration::from_secs(3), driver_handle).await {
+    // Bridge should exit on Stop.
+    match tokio::time::timeout(Duration::from_secs(3), bridge_handle).await {
         Ok(join_result) => {
-            let inner = join_result.expect("driver task join");
-            assert!(inner.is_ok(), "driver returned error: {:?}", inner);
+            let inner = join_result.expect("bridge join");
+            assert!(inner.is_ok(), "bridge returned error: {:?}", inner);
         }
-        Err(_) => panic!("driver did not exit after Stop within 3s"),
+        Err(_) => panic!("bridge did not exit after Stop within 3s"),
     }
+
+    // The QUIT line should also have been written.
+    let lines = captured_lines.lock().await;
+    assert!(
+        lines.iter().any(|l| l == "QUIT"),
+        "QUIT should have been written on Stop; got {:?}",
+        *lines
+    );
 }
 
 #[tokio::test]
-async fn driver_returns_error_when_orchestrator_unreachable() {
-    // Use a port that nothing is listening on.
-    let cfg = test_config("ws://127.0.0.1:1".into());
-    let result = run_orchestrated_mode(cfg).await;
-    assert!(result.is_err());
+async fn driver_bridge_returns_error_when_local_control_port_unreachable() {
+    // Use a real orchestrator URL but a port that nothing's listening on
+    // for the local control bridge.
+    let pool = Arc::new(DriverPool::new(
+        Duration::from_millis(100),
+        Duration::from_secs(2),
+        16,
+    ));
+    let dispatcher = Arc::new(CommandDispatcher::<WsDriverChannel>::new(pool.clone()));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("ws://{}", addr);
+    let pool_for_server = pool.clone();
+    let dispatcher_for_server = dispatcher.clone();
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                return;
+            };
+            let pool = pool_for_server.clone();
+            let dispatcher = dispatcher_for_server.clone();
+            tokio::spawn(async move {
+                let _ = handle_connection(stream, pool, Some(dispatcher)).await;
+            });
+        }
+    });
+
+    let cfg = test_config(url.clone());
+    let state = OrchestratedState::new(cfg.players, cfg.inter_spawn_delay_ms);
+    // Port 1 is reserved + nothing's listening.
+    let result = run_ws_to_tcp_bridge(cfg, 1, state).await;
+    assert!(
+        result.is_err(),
+        "bridge should error on unreachable local port"
+    );
 }


### PR DESCRIPTION
Closes the gap that made yesterday's AWS run silently pass with 0 entities loaded.

## Two changes that go together

**Orchestrator** — `CommandDispatcher::submit` now OWNS per-driver allocation for `SetPlayers`. Controller submits an aggregate target; the dispatcher divides across active drivers (sorted by DriverId for determinism), spreads the remainder across the first `rem` drivers. Sum exactly equals submitted target. Other commands (`SetSpawnDelayMs`, `Stop`) keep broadcast semantics.

**Driver** — `run_orchestrated_mode` is now a WS↔TCP bridge. Picks a free localhost port, runs the existing `run_control_mode` on that port, connects to the orchestrator via WS, translates inbound OrchestratorCommands into the existing TCP control protocol (`SET_PLAYERS N` / `QUIT`). Real players spawn via well-tested control-mode machinery.

## Test status

- `cargo test` — 65 + 21 + 2 + 2 = 90 tests pass across both crates
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- New e2e test (`driver_bridge_relays_set_players_into_local_control_protocol`) verifies controller→orchestrator→WS→bridge→TCP round-trips byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)