### PR TITLE
diag: log on writer/reader exits in driver bridge + orch server

### DIFF
--- a/crates/arcane-swarm-orchestrator/src/server.rs
+++ b/crates/arcane-swarm-orchestrator/src/server.rs
@@ -120,25 +120,28 @@ pub async fn handle_connection(
                         command: cmd,
                     });
                     let Ok(text) = serde_json::to_string(&envelope) else { continue };
-                    if ws_sender
+                    if let Err(e) = ws_sender
                         .send(tokio_tungstenite::tungstenite::Message::Text(text))
                         .await
-                        .is_err()
                     {
+                        eprintln!("orchestrator(server): per-conn writer exit on command send: {}", e);
                         return;
                     }
                 }
                 Some(resp) = resp_rx.recv() => {
                     let Ok(text) = serde_json::to_string(&resp) else { continue };
-                    if ws_sender
+                    if let Err(e) = ws_sender
                         .send(tokio_tungstenite::tungstenite::Message::Text(text))
                         .await
-                        .is_err()
                     {
+                        eprintln!("orchestrator(server): per-conn writer exit on response send: {}", e);
                         return;
                     }
                 }
-                else => return,
+                else => {
+                    eprintln!("orchestrator(server): per-conn writer exit — both channels closed");
+                    return;
+                }
             }
         }
     });

--- a/crates/arcane-swarm/src/orchestrated_mode.rs
+++ b/crates/arcane-swarm/src/orchestrated_mode.rs
@@ -179,28 +179,32 @@ pub async fn run_ws_to_tcp_bridge(
     let writer = tokio::spawn(async move {
         loop {
             if writer_stop.load(Ordering::Relaxed) {
+                eprintln!("arcane-swarm(orchestrated): writer exit — stop signaled");
                 return;
             }
             tokio::select! {
                 Some(msg) = hb_rx.recv() => {
-                    if sender
+                    if let Err(e) = sender
                         .send(Message::Text(serde_json::to_string(&msg).unwrap()))
                         .await
-                        .is_err()
                     {
+                        eprintln!("arcane-swarm(orchestrated): writer exit on heartbeat send: {}", e);
                         return;
                     }
                 }
                 Some(msg) = ack_rx.recv() => {
-                    if sender
+                    if let Err(e) = sender
                         .send(Message::Text(serde_json::to_string(&msg).unwrap()))
                         .await
-                        .is_err()
                     {
+                        eprintln!("arcane-swarm(orchestrated): writer exit on ack send: {}", e);
                         return;
                     }
                 }
-                else => return,
+                else => {
+                    eprintln!("arcane-swarm(orchestrated): writer exit — both channels closed");
+                    return;
+                }
             }
         }
     });
@@ -210,9 +214,13 @@ pub async fn run_ws_to_tcp_bridge(
     while let Some(msg_result) = receiver.next().await {
         let msg = match msg_result {
             Ok(m) => m,
-            Err(_) => break,
+            Err(e) => {
+                eprintln!("arcane-swarm(orchestrated): reader exit on WS error: {}", e);
+                break;
+            }
         };
         if msg.is_close() {
+            eprintln!("arcane-swarm(orchestrated): reader exit — close frame received");
             break;
         }
         if !msg.is_text() {


### PR DESCRIPTION
Diagnostic-only PR — the headline AWS run consistently shows drivers disconnecting after the first 2-3 commands, but without exit logs we can't tell whether the writer task on the driver side or the orchestrator side is dying first.

Adds `eprintln!` on every exit point of the writer/reader loops so the next AWS run produces actionable evidence in container logs.

No behavior change. All 25 tests still pass.