### PR TITLE
fix: change default --players from 100 to 0

### DIFF
--- a/crates/arcane-swarm/src/config.rs
+++ b/crates/arcane-swarm/src/config.rs
@@ -81,7 +81,7 @@ pub struct Config {
 }
 
 pub fn parse_args() -> Config {
-    let mut players: u32 = 100;
+    let mut players: u32 = 0;
     let mut max_players: u32 = 0;
     let mut tick_rate: u32 = 20;
     let mut duration_secs: u64 = 60;
@@ -229,7 +229,7 @@ pub fn parse_args() -> Config {
             "--help" | "-h" => {
                 eprintln!("arcane-swarm: headless client swarm\n");
                 eprintln!("  --backend MODE        spacetimedb | arcane (default spacetimedb)");
-                eprintln!("  --players N            number of simulated players (default 100)");
+                eprintln!("  --players N            number of simulated players (default 0)");
                 eprintln!("  --max-players N       max players for incremental mode (default = --players)");
                 eprintln!("  --tick-rate HZ         ticks per second per player (default 20)");
                 eprintln!("  --duration SECS        how long to run (default 60)");


### PR DESCRIPTION
## Summary

- Changes the `--players` default from 100 to 0 in `crates/arcane-swarm/src/config.rs`
- In orchestrated mode, the benchmark controller sets player counts explicitly per driver. The old default of 100 caused each driver to spawn 100 phantom entities on startup before the controller took over, inflating entity counts by `drivers × 100` and producing invalid benchmark measurements.
- With 20 drivers, this was 2,000 ghost entities — enough to mask the real ceiling entirely.

## Test plan

- [x] `cargo build` passes
- [x] `arcane-swarm --help` shows `default 0`
- [x] Full 8-cluster benchmark run with this fix confirmed entity counts match CCU targets exactly at every tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)