### PR TITLE
feat: FlatBuffers wire validation + driver metrics pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,6 @@ dependencies = [
 [[package]]
 name = "arcane-wire"
 version = "0.1.0"
-source = "git+https://github.com/brainy-bots/arcane.git?branch=epic%2F166-flatbuffers-wire-format#3d02dd32975f49f080116827488b1b3c7cf78bf4"
 dependencies = [
  "crc32fast",
  "flatbuffers",
@@ -2458,7 +2457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
 [[package]]
 name = "arcane-wire"
 version = "0.1.0"
+source = "git+https://github.com/brainy-bots/arcane.git?branch=main#28fb040ff25f85603101a7c21acedbe7ea349a99"
 dependencies = [
  "crc32fast",
  "flatbuffers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,7 @@ name = "arcane-swarm-orchestrator"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "libc",
  "reqwest",
  "serde",
  "serde_json",
@@ -107,10 +108,10 @@ dependencies = [
 [[package]]
 name = "arcane-wire"
 version = "0.1.0"
-source = "git+https://github.com/brainy-bots/arcane.git?branch=main#1af872dc7c3b9fa5f70f5d7bddc842f719becd01"
+source = "git+https://github.com/brainy-bots/arcane.git?branch=epic%2F166-flatbuffers-wire-format#3d02dd32975f49f080116827488b1b3c7cf78bf4"
 dependencies = [
- "postcard",
- "serde",
+ "crc32fast",
+ "flatbuffers",
  "uuid",
 ]
 
@@ -125,15 +126,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
 
 [[package]]
 name = "atomic-waker"
@@ -287,15 +279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,12 +352,6 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -527,18 +504,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +592,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -832,15 +807,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,20 +831,6 @@ dependencies = [
  "rayon",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "serde",
- "spin",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -1505,19 +1457,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "heapless",
- "serde",
-]
 
 [[package]]
 name = "potential_utf"
@@ -2409,15 +2348,6 @@ dependencies = [
  "spacetimedb-lib",
  "sqlparser",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]

--- a/crates/arcane-swarm-orchestrator/Cargo.toml
+++ b/crates/arcane-swarm-orchestrator/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = "1.0"
 uuid = { version = "1", features = ["v4", "serde"] }
 futures = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+libc = "0.2"

--- a/crates/arcane-swarm-orchestrator/src/bin/orchestrator.rs
+++ b/crates/arcane-swarm-orchestrator/src/bin/orchestrator.rs
@@ -143,8 +143,34 @@ fn parse_args() -> Args {
     a
 }
 
+fn raise_fd_limit() {
+    const MIN_SOFT: u64 = 16_384;
+    unsafe {
+        let mut rlim = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) != 0 {
+            eprintln!("WARNING: getrlimit(RLIMIT_NOFILE) failed");
+            return;
+        }
+        let (soft, hard) = (rlim.rlim_cur, rlim.rlim_max);
+        eprintln!("fd limits: soft={soft} hard={hard}");
+        if soft < hard {
+            rlim.rlim_cur = hard;
+            if libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) == 0 {
+                eprintln!("fd limits: raised soft {soft} → {hard}");
+            }
+        }
+        if rlim.rlim_cur < MIN_SOFT {
+            eprintln!(
+                "WARNING: fd soft limit {} is below {MIN_SOFT} — pass --ulimit nofile={MIN_SOFT}:{MIN_SOFT} to docker run",
+                rlim.rlim_cur
+            );
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() {
+    raise_fd_limit();
     let args = parse_args();
 
     eprintln!(

--- a/crates/arcane-swarm-orchestrator/src/bin/orchestrator.rs
+++ b/crates/arcane-swarm-orchestrator/src/bin/orchestrator.rs
@@ -146,7 +146,10 @@ fn parse_args() -> Args {
 fn raise_fd_limit() {
     const MIN_SOFT: u64 = 16_384;
     unsafe {
-        let mut rlim = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+        let mut rlim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
         if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) != 0 {
             eprintln!("WARNING: getrlimit(RLIMIT_NOFILE) failed");
             return;

--- a/crates/arcane-swarm-orchestrator/src/driver_pool.rs
+++ b/crates/arcane-swarm-orchestrator/src/driver_pool.rs
@@ -1,4 +1,4 @@
-use crate::protocol::DriverId;
+use crate::protocol::{DriverId, DriverMetricsReport};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -18,6 +18,7 @@ pub struct DriverEntry {
     pub state: DriverState,
     pub last_heartbeat: Instant,
     pub capabilities: Value,
+    pub latest_metrics: Option<DriverMetricsReport>,
 }
 
 pub struct DriverPool {
@@ -59,6 +60,7 @@ impl DriverPool {
             state: DriverState::Active,
             last_heartbeat: Instant::now(),
             capabilities,
+            latest_metrics: None,
         };
 
         drivers.insert(driver_id, entry);
@@ -74,6 +76,15 @@ impl DriverPool {
 
         entry.last_heartbeat = Instant::now();
         entry.state = DriverState::Active;
+        Ok(())
+    }
+
+    pub async fn update_metrics(&self, report: DriverMetricsReport) -> Result<(), String> {
+        let mut drivers = self.drivers.write().await;
+        let entry = drivers
+            .get_mut(&report.driver_id)
+            .ok_or_else(|| format!("Driver {} not found", report.driver_id))?;
+        entry.latest_metrics = Some(report);
         Ok(())
     }
 

--- a/crates/arcane-swarm-orchestrator/src/protocol.rs
+++ b/crates/arcane-swarm-orchestrator/src/protocol.rs
@@ -15,6 +15,8 @@ pub enum DriverMessage {
     Deregister(DeregisterRequest),
     #[serde(rename = "command_ack")]
     CommandAck(CommandAck),
+    #[serde(rename = "metrics_report")]
+    MetricsReport(DriverMetricsReport),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -25,6 +27,31 @@ pub struct RegisterRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HeartbeatRequest {
     pub driver_id: DriverId,
+}
+
+/// Cumulative driver-side metrics. Sent periodically alongside heartbeats.
+/// Values are running totals since driver start — the consumer computes
+/// deltas between snapshots to derive per-phase or per-interval rates.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DriverMetricsReport {
+    pub driver_id: DriverId,
+    pub ok: u64,
+    pub err: u64,
+    pub latency_sum_us: u64,
+    pub latency_samples: u64,
+    pub max_latency_us: u64,
+    pub bytes: u64,
+    #[serde(default)]
+    pub errors: DriverErrorBreakdown,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DriverErrorBreakdown {
+    pub timeout: u64,
+    pub not_delivered: u64,
+    pub http_status: u64,
+    pub transport: u64,
+    pub connection_drop: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/arcane-swarm-orchestrator/src/server.rs
+++ b/crates/arcane-swarm-orchestrator/src/server.rs
@@ -87,6 +87,10 @@ pub(crate) async fn handle_message(
         DriverMessage::CommandAck(_) => OrchestratorResponse::Error(ErrorResponse {
             message: "CommandAck handled at the connection layer".to_string(),
         }),
+        DriverMessage::MetricsReport(report) => match pool.update_metrics(report).await {
+            Ok(_) => OrchestratorResponse::Ack(AckResponse { driver_id: None }),
+            Err(err) => OrchestratorResponse::Error(ErrorResponse { message: err }),
+        },
     }
 }
 
@@ -199,6 +203,13 @@ pub async fn handle_connection(
                 if let Some(tx) = map.remove(&ack.command_seq) {
                     let _ = tx.send(ack);
                 }
+            }
+            Ok(DriverMessage::MetricsReport(report)) => {
+                let response = match pool.update_metrics(report).await {
+                    Ok(_) => OrchestratorResponse::Ack(AckResponse { driver_id: None }),
+                    Err(err) => OrchestratorResponse::Error(ErrorResponse { message: err }),
+                };
+                let _ = resp_tx.send(response).await;
             }
             Err(e) => {
                 let _ = resp_tx

--- a/crates/arcane-swarm-orchestrator/src/telemetry.rs
+++ b/crates/arcane-swarm-orchestrator/src/telemetry.rs
@@ -12,7 +12,7 @@
 
 use crate::command_dispatcher::{CommandDispatcher, CommandLogEntry, DriverChannel};
 use crate::driver_pool::{DriverPool, DriverState};
-use crate::protocol::{DriverId, OrchestratorCommand};
+use crate::protocol::{DriverErrorBreakdown, DriverId, OrchestratorCommand};
 use crate::stats_collector::{ClusterEndpoint, ClusterStats, StatsCollector};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -32,6 +32,9 @@ pub struct TelemetrySnapshot {
     /// `recent_command_window` entries by the source.
     pub recent_commands: Vec<CommandWireEntry>,
     pub clusters: HashMap<String, ClusterWireStats>,
+    /// Per-driver cumulative metrics (latest report from each driver).
+    #[serde(default)]
+    pub driver_metrics: HashMap<String, DriverMetricsWire>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -59,6 +62,20 @@ pub struct ClusterWireStats {
     pub last_tick_us: u64,
     pub broadcast_lagged_events: u64,
     pub entities_current: u64,
+}
+
+/// Per-driver metrics as they appear in the telemetry snapshot.
+/// Cumulative totals since driver start.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DriverMetricsWire {
+    pub ok: u64,
+    pub err: u64,
+    pub latency_sum_us: u64,
+    pub latency_samples: u64,
+    pub max_latency_us: u64,
+    pub bytes: u64,
+    #[serde(default)]
+    pub errors: DriverErrorBreakdown,
 }
 
 /// The telemetry source.
@@ -146,11 +163,35 @@ impl<C: DriverChannel + 'static, E: ClusterEndpoint + 'static> TelemetrySource<C
             .map(|(url, stats)| (url, wire_cluster(stats)))
             .collect();
 
+        let driver_metrics: HashMap<String, DriverMetricsWire> = self
+            .pool
+            .snapshot()
+            .await
+            .into_iter()
+            .filter_map(|entry| {
+                entry.latest_metrics.map(|m| {
+                    (
+                        entry.id.to_string(),
+                        DriverMetricsWire {
+                            ok: m.ok,
+                            err: m.err,
+                            latency_sum_us: m.latency_sum_us,
+                            latency_samples: m.latency_samples,
+                            max_latency_us: m.max_latency_us,
+                            bytes: m.bytes,
+                            errors: m.errors,
+                        },
+                    )
+                })
+            })
+            .collect();
+
         let snapshot = TelemetrySnapshot {
             snapshot_at_unix_ms,
             fleet,
             recent_commands,
             clusters,
+            driver_metrics,
         };
 
         // Drop send-error: it just means no live subscribers.

--- a/crates/arcane-swarm-orchestrator/src/tests/telemetry_archive.rs
+++ b/crates/arcane-swarm-orchestrator/src/tests/telemetry_archive.rs
@@ -42,6 +42,7 @@ fn synth_snapshot(unix_ms: u128) -> TelemetrySnapshot {
         fleet: Vec::new(),
         recent_commands: Vec::new(),
         clusters,
+        driver_metrics: HashMap::new(),
     }
 }
 

--- a/crates/arcane-swarm/Cargo.toml
+++ b/crates/arcane-swarm/Cargo.toml
@@ -19,9 +19,10 @@ libc = "0.2"
 # stays in sync. Bindings live in src/bin/arcane_swarm/spacetimedb_bindings/ and are
 # produced by `spacetime generate --lang rust --module-path <full module>`.
 spacetimedb-sdk = "2.1"
-# Shared wire schema with the cluster (arcane repo). Local path for
-# development; revert to git dependency before publishing.
-arcane-wire = { path = "../../../../arcane/crates/arcane-wire" }
+# Shared wire schema with the cluster (arcane repo). Path resolves to the
+# arcane submodule inside the benchmarks repo — works both locally and in
+# the Docker build context.
+arcane-wire = { path = "../../../arcane/crates/arcane-wire" }
 # Shared orchestrator wire schema (DriverMessage / OrchestratorResponse /
 # OrchestratorCommand / CommandAck). The orchestrator crate is the source of
 # truth for these types; the driver consumes them under --orchestrator-url.

--- a/crates/arcane-swarm/Cargo.toml
+++ b/crates/arcane-swarm/Cargo.toml
@@ -20,9 +20,7 @@ libc = "0.2"
 # produced by `spacetime generate --lang rust --module-path <full module>`.
 spacetimedb-sdk = "2.1"
 # Shared wire schema with the cluster (arcane repo). Path resolves to the
-# arcane submodule inside the benchmarks repo — works both locally and in
-# the Docker build context.
-arcane-wire = { path = "../../../arcane/crates/arcane-wire" }
+arcane-wire = { git = "https://github.com/brainy-bots/arcane.git", branch = "main" }
 # Shared orchestrator wire schema (DriverMessage / OrchestratorResponse /
 # OrchestratorCommand / CommandAck). The orchestrator crate is the source of
 # truth for these types; the driver consumes them under --orchestrator-url.

--- a/crates/arcane-swarm/Cargo.toml
+++ b/crates/arcane-swarm/Cargo.toml
@@ -19,10 +19,9 @@ libc = "0.2"
 # stays in sync. Bindings live in src/bin/arcane_swarm/spacetimedb_bindings/ and are
 # produced by `spacetime generate --lang rust --module-path <full module>`.
 spacetimedb-sdk = "2.1"
-# Shared wire schema with the cluster (arcane repo). Temporarily pinned to
-# the FlatBuffers epic branch for end-to-end validation (arcane#166).
-# Revert to branch = "main" once the epic merges.
-arcane-wire = { git = "https://github.com/brainy-bots/arcane.git", branch = "epic/166-flatbuffers-wire-format" }
+# Shared wire schema with the cluster (arcane repo). Local path for
+# development; revert to git dependency before publishing.
+arcane-wire = { path = "../../../../arcane/crates/arcane-wire" }
 # Shared orchestrator wire schema (DriverMessage / OrchestratorResponse /
 # OrchestratorCommand / CommandAck). The orchestrator crate is the source of
 # truth for these types; the driver consumes them under --orchestrator-url.

--- a/crates/arcane-swarm/Cargo.toml
+++ b/crates/arcane-swarm/Cargo.toml
@@ -19,11 +19,10 @@ libc = "0.2"
 # stays in sync. Bindings live in src/bin/arcane_swarm/spacetimedb_bindings/ and are
 # produced by `spacetime generate --lang rust --module-path <full module>`.
 spacetimedb-sdk = "2.1"
-# Shared wire schema with the cluster (arcane repo). Pinned to main so
-# the benchmark tracks the latest protocol; the benchmark workspace pins
-# both arcane and arcane_swarm as submodules, so this resolves to the
-# same commit in the benchmark CI.
-arcane-wire = { git = "https://github.com/brainy-bots/arcane.git", branch = "main" }
+# Shared wire schema with the cluster (arcane repo). Temporarily pinned to
+# the FlatBuffers epic branch for end-to-end validation (arcane#166).
+# Revert to branch = "main" once the epic merges.
+arcane-wire = { git = "https://github.com/brainy-bots/arcane.git", branch = "epic/166-flatbuffers-wire-format" }
 # Shared orchestrator wire schema (DriverMessage / OrchestratorResponse /
 # OrchestratorCommand / CommandAck). The orchestrator crate is the source of
 # truth for these types; the driver consumes them under --orchestrator-url.

--- a/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
@@ -229,11 +229,7 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
                             let mut ft = flight_drain.lock().await;
                             if let Some(sent_at) = ft.remove(&echoed_seq) {
                                 let rtt = sent_at.elapsed();
-                                latency_metrics.record_ok_decomposed(
-                                    rtt,
-                                    None,
-                                    Duration::ZERO,
-                                );
+                                latency_metrics.record_ok_decomposed(rtt, None, Duration::ZERO);
                                 *ft = ft.split_off(&(echoed_seq + 1));
                             }
                         }

--- a/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
@@ -4,27 +4,19 @@
 //!
 //! ## What the "lat" column means here
 //!
-//! The client's outbound writes are fire-and-forget WebSocket frames —
-//! `sink.send(Message::Binary(_))` returns in nanoseconds once the bytes are
-//! queued in the local send buffer, regardless of whether the cluster is
-//! healthy, lagging, or dead. Timing the call site is therefore meaningless.
-//!
-//! Instead the swarm measures **client-perceived latency**: the wall-clock
-//! gap between "I wrote state at T0" and "the cluster's next broadcast frame
-//! carrying my own entity landed in my receive buffer at T1". That's what a
-//! real game client experiences — action → world-reflection. Under server
-//! load the cluster's tick slides later, the broadcast arrives late, and the
-//! number rises. Under catastrophic load the broadcast stops, and the
-//! `NotDelivered` / `ConnectionDrop` counters pick up.
-//!
-//! The swarm decodes each incoming binary frame via
-//! [`arcane_wire::decode_server`] and walks `DeltaPayload::updated`; when it
-//! finds its own `entity_id` it computes `now - last_send` and records the
-//! sample. Every outbound write (movement or action) updates `last_send`.
+//! The swarm measures **sequence-tagged round-trip latency**: each outbound
+//! `PlayerState` frame carries a monotonic `client_seq` and records the send
+//! `Instant` in a per-player flight table. The cluster echoes `client_seq`
+//! through the entity state back in the broadcast. When the drain task sees
+//! its own entity in a broadcast, it reads the echoed `client_seq`, looks up
+//! the flight table, and computes RTT = `Instant::now() - sent_at`. This
+//! measures the true end-to-end round trip for each specific send, immune to
+//! overwrite artifacts from the previous `last_send` atomic approach.
 
-use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use arcane_wire::{decode_server, ServerFrame};
 use futures_util::{SinkExt, StreamExt};
@@ -188,34 +180,20 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
     };
     let (mut sink, mut stream) = ws_stream.split();
 
-    // Shared micros-since-run-start of the player's most recent outbound write
-    // (movement or action). The drain task reads this when it spots the
-    // player's own entity_id in an incoming broadcast frame and computes
-    // latency = now - last_send. Using a shared atomic rather than passing
-    // through a channel keeps the hot paths lock-free.
-    let last_send_micros = Arc::new(AtomicI64::new(-1));
-    // Same instant in UNIX micros — used for the cross-clock T2 - T1 wire
-    // portion of the latency decomposition. Updated alongside
-    // `last_send_micros` at every outbound write so they refer to the same
-    // moment.
-    let last_send_unix_us = Arc::new(AtomicI64::new(-1));
+    let flight_table: Arc<tokio::sync::Mutex<BTreeMap<u64, std::time::Instant>>> =
+        Arc::new(tokio::sync::Mutex::new(BTreeMap::new()));
+    let mut next_seq: u64 = 0;
 
     let stop_drain = stop.clone();
     let rm = read_metrics.clone();
     let latency_metrics = metrics.clone();
-    let last_send_drain = last_send_micros.clone();
-    let last_send_unix_drain = last_send_unix_us.clone();
     let my_id = player.id;
-    let drain_run_started = run_started;
     let cache_drain = delta_cache.clone();
+    let flight_drain = flight_table.clone();
     tokio::spawn(async move {
         while !stop_drain.load(Ordering::Relaxed) {
             match stream.next().await {
                 Some(Ok(Message::Binary(bin))) => {
-                    // T_arrival: capture immediately, before any decode or
-                    // cache work, so `drain_us = T3 - T_arrival` is purely
-                    // on-driver post-receive cost. Clock-sync free.
-                    let arrival_us = drain_run_started.elapsed().as_micros() as i64;
                     rm.record_inbound_ok(bin.len() as u64);
                     // Cache lookup first. The cluster encodes each broadcast
                     // once and sends the same bytes to every connected
@@ -230,9 +208,15 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
                             Ok(ServerFrame::Delta(payload)) => {
                                 let entity_ids: HashSet<_> =
                                     payload.updated.iter().map(|e| e.entity_id).collect();
+                                let client_seqs: HashMap<_, _> = payload
+                                    .updated
+                                    .iter()
+                                    .filter(|e| e.client_seq != 0)
+                                    .map(|e| (e.entity_id, e.client_seq))
+                                    .collect();
                                 let entry = Arc::new(CachedDelta {
                                     entity_ids,
-                                    server_ts: payload.timestamp,
+                                    client_seqs,
                                 });
                                 cache_drain.insert(&bin, entry.clone());
                                 entry
@@ -240,36 +224,18 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
                             Err(_) => continue,
                         },
                     };
-                    if cached.entity_ids.contains(&my_id) {
-                        let sent = last_send_drain.load(Ordering::Relaxed);
-                        if sent >= 0 {
-                            let now = drain_run_started.elapsed().as_micros() as i64;
-                            let total_us = (now - sent).max(0) as u64;
-                            let drain_us = (now - arrival_us).max(0) as u64;
-                            // Wire portion: T2 (server stamp, UNIX seconds
-                            // f64) − T1 (driver's send moment in UNIX
-                            // micros). Endpoints chrony-synced to ~1ms on
-                            // AWS; clock-skew bias is folded here.
-                            // `server_ts <= 0.0` means the server didn't
-                            // stamp this frame (older image), skip wire
-                            // sample.
-                            let wire_lat = if cached.server_ts > 0.0 {
-                                let sent_unix = last_send_unix_drain.load(Ordering::Relaxed);
-                                if sent_unix > 0 {
-                                    let server_us = (cached.server_ts * 1_000_000.0) as i64;
-                                    let wire_us = (server_us - sent_unix).max(0) as u64;
-                                    Some(Duration::from_micros(wire_us))
-                                } else {
-                                    None
-                                }
-                            } else {
-                                None
-                            };
-                            latency_metrics.record_ok_decomposed(
-                                Duration::from_micros(total_us),
-                                wire_lat,
-                                Duration::from_micros(drain_us),
-                            );
+                    if let Some(&echoed_seq) = cached.client_seqs.get(&my_id) {
+                        if echoed_seq > 0 {
+                            let mut ft = flight_drain.lock().await;
+                            if let Some(sent_at) = ft.remove(&echoed_seq) {
+                                let rtt = sent_at.elapsed();
+                                latency_metrics.record_ok_decomposed(
+                                    rtt,
+                                    None,
+                                    Duration::ZERO,
+                                );
+                                *ft = ft.split_off(&(echoed_seq + 1));
+                            }
                         }
                     }
                 }
@@ -326,8 +292,7 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
             );
         }
 
-        // Send movement — binary FlatBuffer frame for fairness with SpacetimeDB's
-        // BSATN. See brainy-bots/arcane#28 for motivation.
+        next_seq += 1;
         let msg = encode_player_state(
             &player.id,
             player.x,
@@ -337,17 +302,15 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
             player.vy,
             player.vz,
             &user_data_buf,
+            next_seq,
         );
         match sink.send(Message::Binary(msg)).await {
             Ok(_) => {
-                // Count the successful enqueue; latency is recorded by the
-                // drain task when it sees the cluster echo this write back.
                 metrics.record_ok_count();
-                last_send_micros.store(run_started.elapsed().as_micros() as i64, Ordering::Relaxed);
-                // UNIX wall-clock copy of the same moment for the wire
-                // (T2 - T1) portion of the latency decomposition.
-                if let Ok(d) = SystemTime::now().duration_since(UNIX_EPOCH) {
-                    last_send_unix_us.store(d.as_micros() as i64, Ordering::Relaxed);
+                let mut ft = flight_table.lock().await;
+                ft.insert(next_seq, std::time::Instant::now());
+                if ft.len() > 1024 {
+                    ft.pop_first();
                 }
             }
             Err(e) => {
@@ -369,15 +332,7 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
                 let action_msg = encode_game_action(&player.id, action_type, payload.as_bytes());
                 match sink.send(Message::Binary(action_msg)).await {
                     Ok(_) => {
-                        // Same pattern as movement: count the enqueue; the
-                        // next echo carrying our entity provides the latency
-                        // sample for the combined write stream.
                         action_metrics.record_ok_count();
-                        last_send_micros
-                            .store(run_started.elapsed().as_micros() as i64, Ordering::Relaxed);
-                        if let Ok(d) = SystemTime::now().duration_since(UNIX_EPOCH) {
-                            last_send_unix_us.store(d.as_micros() as i64, Ordering::Relaxed);
-                        }
                     }
                     Err(e) => {
                         action_metrics.record_err();

--- a/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/backends_arcane.rs
@@ -111,7 +111,7 @@ pub(crate) struct ArcanePlayerLoop {
     pub burst: BurstConfig,
     pub run_started: std::time::Instant,
     /// Per-driver shared decode cache. The drain task consults this before
-    /// running a full `decode_server`; on hit it skips the postcard parse
+    /// running a full `decode_server`; on hit it skips the FlatBuffer decode
     /// entirely and reads the cached entity-id set. See `delta_cache.rs`
     /// for the architecture rationale.
     pub delta_cache: Arc<DeltaCache>,
@@ -223,7 +223,7 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
                     // identical payloads — decoding 1437× is wasted work.
                     // The first drain to see this frame decodes it and
                     // populates the cache; the rest hit the cache and skip
-                    // the postcard parse. See `delta_cache.rs`.
+                    // the FlatBuffer decode. See `delta_cache.rs`.
                     let cached: Arc<CachedDelta> = match cache_drain.lookup(&bin) {
                         Some(e) => e,
                         None => match decode_server(&bin) {
@@ -326,7 +326,7 @@ pub(crate) async fn player_loop_arcane(ctx: ArcanePlayerLoop) {
             );
         }
 
-        // Send movement — binary postcard frame for fairness with SpacetimeDB's
+        // Send movement — binary FlatBuffer frame for fairness with SpacetimeDB's
         // BSATN. See brainy-bots/arcane#28 for motivation.
         let msg = encode_player_state(
             &player.id,

--- a/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
@@ -566,8 +566,34 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
 
 // -- Main ------------------------------------------------------------------
 
+fn raise_fd_limit() {
+    const MIN_SOFT: u64 = 16_384;
+    unsafe {
+        let mut rlim = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) != 0 {
+            eprintln!("WARNING: getrlimit(RLIMIT_NOFILE) failed");
+            return;
+        }
+        let (soft, hard) = (rlim.rlim_cur, rlim.rlim_max);
+        eprintln!("fd limits: soft={soft} hard={hard}");
+        if soft < hard {
+            rlim.rlim_cur = hard;
+            if libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) == 0 {
+                eprintln!("fd limits: raised soft {soft} → {hard}");
+            }
+        }
+        if rlim.rlim_cur < MIN_SOFT {
+            eprintln!(
+                "WARNING: fd soft limit {} is below {MIN_SOFT} — pass --ulimit nofile={MIN_SOFT}:{MIN_SOFT} to docker run",
+                rlim.rlim_cur
+            );
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() {
+    raise_fd_limit();
     let cfg = parse_args();
     let run_started = std::time::Instant::now();
     let tick_interval = Duration::from_micros(1_000_000 / cfg.tick_rate as u64);

--- a/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
+++ b/crates/arcane-swarm/src/bin/arcane_swarm/main.rs
@@ -180,7 +180,11 @@ impl BackendRuntime for ArcaneRuntime {
     }
 }
 
-async fn run_control_mode(cfg: Config, tick_interval: Duration) {
+async fn run_control_mode(
+    cfg: Config,
+    tick_interval: Duration,
+    external_metrics: Option<Arc<Metrics>>,
+) {
     let run_started = std::time::Instant::now();
     let stdb_base = cfg.spacetimedb_uri.trim_end_matches('/').to_string();
     // SDK requires a ws:// or wss:// URI rather than http://.
@@ -188,7 +192,7 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
         .replacen("https://", "wss://", 1)
         .replacen("http://", "ws://", 1);
 
-    let metrics = Arc::new(Metrics::new());
+    let metrics = external_metrics.unwrap_or_else(|| Arc::new(Metrics::new()));
     let action_metrics = Arc::new(Metrics::new());
     let read_metrics = Arc::new(Metrics::new());
 
@@ -569,7 +573,10 @@ async fn run_control_mode(cfg: Config, tick_interval: Duration) {
 fn raise_fd_limit() {
     const MIN_SOFT: u64 = 16_384;
     unsafe {
-        let mut rlim = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+        let mut rlim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
         if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) != 0 {
             eprintln!("WARNING: getrlimit(RLIMIT_NOFILE) failed");
             return;
@@ -647,9 +654,14 @@ async fn main() {
         // initial cfg.players up before any orchestrator command lands.
         cfg_for_control.players = 0;
 
+        // Pre-create metrics so the WS bridge can report cumulative totals
+        // to the orchestrator while the control loop uses the same counters.
+        let shared_metrics = Arc::new(Metrics::new());
+
         let cfg_for_bridge = cfg.clone();
         let state =
-            orchestrated_mode::OrchestratedState::new(cfg.players, cfg.inter_spawn_delay_ms);
+            orchestrated_mode::OrchestratedState::new(cfg.players, cfg.inter_spawn_delay_ms)
+                .with_metrics(shared_metrics.clone());
         let bridge_state = state.clone();
         let bridge = tokio::spawn(async move {
             if let Err(e) =
@@ -660,13 +672,13 @@ async fn main() {
             }
         });
 
-        run_control_mode(cfg_for_control, tick_interval).await;
+        run_control_mode(cfg_for_control, tick_interval, Some(shared_metrics)).await;
         let _ = bridge.await;
         return;
     }
 
     if cfg.run_forever || cfg.control_port > 0 {
-        run_control_mode(cfg, tick_interval).await;
+        run_control_mode(cfg, tick_interval, None).await;
         return;
     }
 

--- a/crates/arcane-swarm/src/delta_cache.rs
+++ b/crates/arcane-swarm/src/delta_cache.rs
@@ -50,9 +50,9 @@ pub struct CachedDelta {
 
 /// Bounded byte-keyed cache of decoded broadcast deltas.
 ///
-/// The key is the first 32 bytes of the postcard-encoded frame. Those bytes
-/// always include the postcard variant discriminator (1B) + source_cluster_id
-/// (16B) + the start of seq+tick varints, which is enough to uniquely
+/// The key is the first 32 bytes of the FlatBuffer-encoded frame. Those bytes
+/// always include the FlatBuffer root offset + union discriminator +
+/// source_cluster_id (16B) + seq/tick fields, which is enough to uniquely
 /// identify a broadcast in practice — broadcasts from different
 /// (cluster, tick) pairs differ in at least one of those bytes, and bytes
 /// from the *same* broadcast sent to multiple players are bit-for-bit

--- a/crates/arcane-swarm/src/delta_cache.rs
+++ b/crates/arcane-swarm/src/delta_cache.rs
@@ -206,9 +206,9 @@ mod tests {
             );
         }
         // First entry should have been evicted.
-        assert!(cache.lookup(&vec![0u8; 16]).is_none());
-        assert!(cache.lookup(&vec![1u8; 16]).is_some());
-        assert!(cache.lookup(&vec![2u8; 16]).is_some());
+        assert!(cache.lookup(&[0u8; 16]).is_none());
+        assert!(cache.lookup(&[1u8; 16]).is_some());
+        assert!(cache.lookup(&[2u8; 16]).is_some());
     }
 
     #[test]

--- a/crates/arcane-swarm/src/delta_cache.rs
+++ b/crates/arcane-swarm/src/delta_cache.rs
@@ -32,6 +32,7 @@
 //! Today's full-mesh wire makes it maximally effective.
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
@@ -48,29 +49,23 @@ pub struct CachedDelta {
     pub client_seqs: HashMap<Uuid, u64>,
 }
 
-/// Bounded byte-keyed cache of decoded broadcast deltas.
+/// Bounded hash-keyed cache of decoded broadcast deltas.
 ///
-/// The key is the first 32 bytes of the FlatBuffer-encoded frame. Those bytes
-/// always include the FlatBuffer root offset + union discriminator +
-/// source_cluster_id (16B) + seq/tick fields, which is enough to uniquely
-/// identify a broadcast in practice — broadcasts from different
-/// (cluster, tick) pairs differ in at least one of those bytes, and bytes
-/// from the *same* broadcast sent to multiple players are bit-for-bit
-/// identical (the cluster encodes once and reuses the bytes).
+/// The key is a SipHash of the full frame. FlatBuffer field layout puts
+/// tick/seq/timestamp past byte 32, so a prefix key would collide across
+/// ticks from the same cluster. Full-frame hashing is still orders of
+/// magnitude cheaper than a FlatBuffer decode.
 ///
-/// Eviction is simple FIFO. Order of insertion doesn't perfectly match
-/// recency, but recent broadcasts dominate lookups so a young entry rarely
-/// gets evicted before its lookups settle. With `max_entries` sized for a
-/// few seconds of broadcasts, hit rate stays near-100% even with sloppy
-/// eviction.
+/// Eviction is simple FIFO. Recent broadcasts dominate lookups so a young
+/// entry rarely gets evicted before its lookups settle.
 pub struct DeltaCache {
     inner: Mutex<DeltaCacheInner>,
     max_entries: usize,
 }
 
 struct DeltaCacheInner {
-    map: HashMap<[u8; 32], Arc<CachedDelta>>,
-    order: VecDeque<[u8; 32]>,
+    map: HashMap<u64, Arc<CachedDelta>>,
+    order: VecDeque<u64>,
     hits: u64,
     misses: u64,
 }
@@ -88,14 +83,10 @@ impl DeltaCache {
         }
     }
 
-    /// Build the cache key from the first 32 bytes of a frame. Pads with
-    /// zeros if the frame is shorter (shouldn't happen for real broadcasts;
-    /// defensive only).
-    fn key_for(bytes: &[u8]) -> [u8; 32] {
-        let mut key = [0u8; 32];
-        let n = bytes.len().min(32);
-        key[..n].copy_from_slice(&bytes[..n]);
-        key
+    fn key_for(bytes: &[u8]) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        bytes.hash(&mut hasher);
+        hasher.finish()
     }
 
     /// Look up the cached decode for a frame. Returns `Some` on hit, `None`
@@ -119,8 +110,7 @@ impl DeltaCache {
         }
     }
 
-    /// Insert a fresh decode result keyed by the same first-32-byte slice
-    /// `lookup` would compute. If multiple drain tasks raced and each
+    /// Insert a fresh decode result. If multiple drain tasks raced and each
     /// decoded redundantly before the first insert landed, the duplicate
     /// inserts are harmless — they overwrite with equivalent data.
     pub fn insert(&self, bytes: &[u8], entry: Arc<CachedDelta>) {
@@ -167,5 +157,79 @@ impl Default for DeltaCache {
         // Sized for ~5s of broadcasts at 4 clusters × 20 Hz = 400 entries,
         // with headroom. Memory bound: 1000 × 23 KB ≈ 23 MB worst case.
         Self::new(1000)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distinct_frames_get_distinct_keys() {
+        let mut frame_a = vec![0u8; 80];
+        let mut frame_b = vec![0u8; 80];
+        // Identical prefix (simulates FlatBuffer vtable/offset region),
+        // differ only in later bytes (simulates seq/tick/timestamp fields).
+        frame_a[40] = 1;
+        frame_b[40] = 2;
+        assert_ne!(
+            DeltaCache::key_for(&frame_a),
+            DeltaCache::key_for(&frame_b),
+            "frames differing only past byte 32 must produce different cache keys"
+        );
+    }
+
+    #[test]
+    fn lookup_returns_inserted_entry() {
+        let cache = DeltaCache::new(10);
+        let frame = b"test-frame-bytes";
+        let entry = Arc::new(CachedDelta {
+            entity_ids: HashSet::new(),
+            client_seqs: HashMap::new(),
+        });
+        assert!(cache.lookup(frame).is_none());
+        cache.insert(frame, entry.clone());
+        assert!(cache.lookup(frame).is_some());
+    }
+
+    #[test]
+    fn eviction_respects_capacity() {
+        let cache = DeltaCache::new(2);
+        for i in 0u8..3 {
+            let frame = vec![i; 16];
+            cache.insert(
+                &frame,
+                Arc::new(CachedDelta {
+                    entity_ids: HashSet::new(),
+                    client_seqs: HashMap::new(),
+                }),
+            );
+        }
+        // First entry should have been evicted.
+        assert!(cache.lookup(&vec![0u8; 16]).is_none());
+        assert!(cache.lookup(&vec![1u8; 16]).is_some());
+        assert!(cache.lookup(&vec![2u8; 16]).is_some());
+    }
+
+    #[test]
+    fn hit_miss_counters_track_correctly() {
+        let cache = DeltaCache::new(10);
+        let frame = b"counter-test";
+        cache.insert(
+            frame,
+            Arc::new(CachedDelta {
+                entity_ids: HashSet::new(),
+                client_seqs: HashMap::new(),
+            }),
+        );
+        cache.lookup(frame); // hit
+        cache.lookup(frame); // hit
+        cache.lookup(b"missing"); // miss
+        let (hits, misses) = cache.snapshot_and_reset_counters();
+        assert_eq!(hits, 2);
+        assert_eq!(misses, 1);
+        let (h2, m2) = cache.snapshot_and_reset_counters();
+        assert_eq!(h2, 0);
+        assert_eq!(m2, 0);
     }
 }

--- a/crates/arcane-swarm/src/delta_cache.rs
+++ b/crates/arcane-swarm/src/delta_cache.rs
@@ -45,7 +45,7 @@ use uuid::Uuid;
 /// covers seconds of broadcasts across all clusters.
 pub struct CachedDelta {
     pub entity_ids: HashSet<Uuid>,
-    pub server_ts: f64,
+    pub client_seqs: HashMap<Uuid, u64>,
 }
 
 /// Bounded byte-keyed cache of decoded broadcast deltas.

--- a/crates/arcane-swarm/src/metrics.rs
+++ b/crates/arcane-swarm/src/metrics.rs
@@ -100,6 +100,18 @@ pub struct MetricsSnapshot {
     pub drain_latency_samples: u64,
 }
 
+/// Cumulative (never-reset) totals readable by the orchestrator bridge.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CumulativeMetrics {
+    pub ok: u64,
+    pub err: u64,
+    pub latency_sum_us: u64,
+    pub latency_samples: u64,
+    pub max_latency_us: u64,
+    pub bytes: u64,
+    pub errors: ErrorBreakdown,
+}
+
 /// Thread-safe rolling metrics for OK/err counts and latencies (microseconds).
 pub struct Metrics {
     ok: AtomicU64,
@@ -121,6 +133,19 @@ pub struct Metrics {
     drain_latency_sum_us: AtomicU64,
     drain_latency_max_us: AtomicU64,
     drain_latency_samples: AtomicU64,
+    // Cumulative counters — never reset. Used by the orchestrator bridge
+    // to report running totals to the controller.
+    cum_ok: AtomicU64,
+    cum_err: AtomicU64,
+    cum_latency_sum_us: AtomicU64,
+    cum_latency_samples: AtomicU64,
+    cum_max_latency_us: AtomicU64,
+    cum_bytes: AtomicU64,
+    cum_err_timeout: AtomicU64,
+    cum_err_not_delivered: AtomicU64,
+    cum_err_http_status: AtomicU64,
+    cum_err_transport: AtomicU64,
+    cum_err_connection_drop: AtomicU64,
 }
 
 impl Metrics {
@@ -143,6 +168,17 @@ impl Metrics {
             drain_latency_sum_us: AtomicU64::new(0),
             drain_latency_max_us: AtomicU64::new(0),
             drain_latency_samples: AtomicU64::new(0),
+            cum_ok: AtomicU64::new(0),
+            cum_err: AtomicU64::new(0),
+            cum_latency_sum_us: AtomicU64::new(0),
+            cum_latency_samples: AtomicU64::new(0),
+            cum_max_latency_us: AtomicU64::new(0),
+            cum_bytes: AtomicU64::new(0),
+            cum_err_timeout: AtomicU64::new(0),
+            cum_err_not_delivered: AtomicU64::new(0),
+            cum_err_http_status: AtomicU64::new(0),
+            cum_err_transport: AtomicU64::new(0),
+            cum_err_connection_drop: AtomicU64::new(0),
         }
     }
 
@@ -185,6 +221,10 @@ impl Metrics {
         self.latency_sum_us.fetch_add(us, Ordering::Relaxed);
         self.latency_samples.fetch_add(1, Ordering::Relaxed);
         self.latency_max_us.fetch_max(us, Ordering::Relaxed);
+        self.cum_ok.fetch_add(1, Ordering::Relaxed);
+        self.cum_latency_sum_us.fetch_add(us, Ordering::Relaxed);
+        self.cum_latency_samples.fetch_add(1, Ordering::Relaxed);
+        self.cum_max_latency_us.fetch_max(us, Ordering::Relaxed);
     }
 
     /// Record a successful operation without contributing a latency sample.
@@ -198,11 +238,13 @@ impl Metrics {
     /// `backends_spacetimedb` in the binary crate).
     pub fn record_ok_count(&self) {
         self.ok.fetch_add(1, Ordering::Relaxed);
+        self.cum_ok.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn record_ok_bytes(&self, latency: Duration, bytes: u64) {
         self.record_ok(latency);
         self.bytes.fetch_add(bytes, Ordering::Relaxed);
+        self.cum_bytes.fetch_add(bytes, Ordering::Relaxed);
     }
 
     pub fn record_err(&self) {
@@ -211,21 +253,27 @@ impl Metrics {
 
     pub fn record_err_kind(&self, kind: ErrorKind) {
         self.err.fetch_add(1, Ordering::Relaxed);
+        self.cum_err.fetch_add(1, Ordering::Relaxed);
         match kind {
             ErrorKind::Timeout => {
                 self.err_timeout.fetch_add(1, Ordering::Relaxed);
+                self.cum_err_timeout.fetch_add(1, Ordering::Relaxed);
             }
             ErrorKind::NotDelivered => {
                 self.err_not_delivered.fetch_add(1, Ordering::Relaxed);
+                self.cum_err_not_delivered.fetch_add(1, Ordering::Relaxed);
             }
             ErrorKind::HttpStatus => {
                 self.err_http_status.fetch_add(1, Ordering::Relaxed);
+                self.cum_err_http_status.fetch_add(1, Ordering::Relaxed);
             }
             ErrorKind::Transport => {
                 self.err_transport.fetch_add(1, Ordering::Relaxed);
+                self.cum_err_transport.fetch_add(1, Ordering::Relaxed);
             }
             ErrorKind::ConnectionDrop => {
                 self.err_connection_drop.fetch_add(1, Ordering::Relaxed);
+                self.cum_err_connection_drop.fetch_add(1, Ordering::Relaxed);
             }
         }
     }
@@ -234,6 +282,8 @@ impl Metrics {
     pub fn record_inbound_ok(&self, payload_bytes: u64) {
         self.ok.fetch_add(1, Ordering::Relaxed);
         self.bytes.fetch_add(payload_bytes, Ordering::Relaxed);
+        self.cum_ok.fetch_add(1, Ordering::Relaxed);
+        self.cum_bytes.fetch_add(payload_bytes, Ordering::Relaxed);
     }
 
     pub fn snapshot_and_reset(&self) -> MetricsSnapshot {
@@ -272,6 +322,26 @@ impl Metrics {
             avg_drain_latency_us: drain_sum.checked_div(drain_n).unwrap_or(0),
             max_drain_latency_us: drain_max,
             drain_latency_samples: drain_n,
+        }
+    }
+
+    /// Read cumulative (never-reset) totals. Safe to call concurrently with
+    /// `record_*` and `snapshot_and_reset` — uses its own set of atomics.
+    pub fn cumulative(&self) -> CumulativeMetrics {
+        CumulativeMetrics {
+            ok: self.cum_ok.load(Ordering::Relaxed),
+            err: self.cum_err.load(Ordering::Relaxed),
+            latency_sum_us: self.cum_latency_sum_us.load(Ordering::Relaxed),
+            latency_samples: self.cum_latency_samples.load(Ordering::Relaxed),
+            max_latency_us: self.cum_max_latency_us.load(Ordering::Relaxed),
+            bytes: self.cum_bytes.load(Ordering::Relaxed),
+            errors: ErrorBreakdown {
+                timeout: self.cum_err_timeout.load(Ordering::Relaxed),
+                not_delivered: self.cum_err_not_delivered.load(Ordering::Relaxed),
+                http_status: self.cum_err_http_status.load(Ordering::Relaxed),
+                transport: self.cum_err_transport.load(Ordering::Relaxed),
+                connection_drop: self.cum_err_connection_drop.load(Ordering::Relaxed),
+            },
         }
     }
 }

--- a/crates/arcane-swarm/src/orchestrated_mode.rs
+++ b/crates/arcane-swarm/src/orchestrated_mode.rs
@@ -14,10 +14,12 @@
 //!
 //! Standalone mode (no `--orchestrator-url`) is unchanged.
 
+use crate::metrics::Metrics;
 use crate::{Backend, Config};
 use arcane_swarm_orchestrator::protocol::{
-    CommandAck, CommandEnvelope, DeregisterRequest, DriverMessage, HeartbeatRequest,
-    OrchestratorCommand, OrchestratorResponse, RegisterRequest,
+    CommandAck, CommandEnvelope, DeregisterRequest, DriverErrorBreakdown, DriverMessage,
+    DriverMetricsReport, HeartbeatRequest, OrchestratorCommand, OrchestratorResponse,
+    RegisterRequest,
 };
 use futures_util::{SinkExt, StreamExt};
 use serde_json::json;
@@ -36,6 +38,7 @@ pub struct OrchestratedState {
     pub target_players: Arc<AtomicU32>,
     pub spawn_delay_ms: Arc<AtomicU32>,
     pub stop: Arc<AtomicBool>,
+    pub metrics: Option<Arc<Metrics>>,
 }
 
 impl OrchestratedState {
@@ -44,7 +47,13 @@ impl OrchestratedState {
             target_players: Arc::new(AtomicU32::new(initial_players)),
             spawn_delay_ms: Arc::new(AtomicU32::new(initial_spawn_delay_ms)),
             stop: Arc::new(AtomicBool::new(false)),
+            metrics: None,
         }
+    }
+
+    pub fn with_metrics(mut self, metrics: Arc<Metrics>) -> Self {
+        self.metrics = Some(metrics);
+        self
     }
 }
 
@@ -152,10 +161,11 @@ pub async fn run_ws_to_tcp_bridge(
         .write_all(format!("SET_PLAYERS {}\n", cfg.players).as_bytes())
         .await;
 
-    // Heartbeat task — independent of the read loop so missed heartbeats
-    // are determined by wall-clock, not message arrival rate.
-    let (hb_tx, mut hb_rx) = tokio::sync::mpsc::channel::<DriverMessage>(8);
+    // Heartbeat + metrics reporting task — independent of the read loop so
+    // missed heartbeats are determined by wall-clock, not message arrival rate.
+    let (hb_tx, mut hb_rx) = tokio::sync::mpsc::channel::<DriverMessage>(16);
     let hb_state_stop = state.stop.clone();
+    let hb_metrics = state.metrics.clone();
     tokio::spawn(async move {
         let mut ticker = time::interval(Duration::from_secs(5));
         loop {
@@ -169,6 +179,26 @@ pub async fn run_ws_to_tcp_bridge(
                 .is_err()
             {
                 return;
+            }
+            if let Some(ref m) = hb_metrics {
+                let cum = m.cumulative();
+                let report = DriverMetricsReport {
+                    driver_id,
+                    ok: cum.ok,
+                    err: cum.err,
+                    latency_sum_us: cum.latency_sum_us,
+                    latency_samples: cum.latency_samples,
+                    max_latency_us: cum.max_latency_us,
+                    bytes: cum.bytes,
+                    errors: DriverErrorBreakdown {
+                        timeout: cum.errors.timeout,
+                        not_delivered: cum.errors.not_delivered,
+                        http_status: cum.errors.http_status,
+                        transport: cum.errors.transport,
+                        connection_drop: cum.errors.connection_drop,
+                    },
+                };
+                let _ = hb_tx.send(DriverMessage::MetricsReport(report)).await;
             }
         }
     });

--- a/crates/arcane-swarm/src/protocol.rs
+++ b/crates/arcane-swarm/src/protocol.rs
@@ -1,6 +1,6 @@
 //! Wire-format helpers shared by backends (e.g. Arcane WebSocket payloads).
 //!
-//! The Arcane wire protocol uses postcard-encoded binary frames from
+//! The Arcane wire protocol uses FlatBuffer-encoded binary frames from
 //! [`arcane_wire`]. This module exposes small helpers that build the
 //! binary frame bytes from the values a backend loop already has on hand,
 //! so backend code doesn't need to know about the wire schema.
@@ -15,7 +15,7 @@ use arcane_wire::{
 /// Spatial query radius (server units) for SpacetimeDB read simulation.
 pub const VISIBILITY_RADIUS: f64 = 1500.0;
 
-/// Encode one `PLAYER_STATE` frame as postcard bytes for the Arcane cluster
+/// Encode one `PLAYER_STATE` frame as FlatBuffer bytes for the Arcane cluster
 /// WebSocket. Returned bytes are ready to send as `Message::Binary`.
 ///
 /// `user_data` is opaque per-entity payload that flows through the cluster's
@@ -46,10 +46,7 @@ pub fn encode_player_state(
         velocity: Vec3Q::from_vec3(WireVec3::new(vx, vy, vz)),
         user_data: user_data.to_vec(),
     });
-    // encode_client returns Err only on allocator failure or serialize-bug;
-    // both are fatal rather than recoverable for a benchmark client — unwrap
-    // so any such bug fails loudly instead of silently dropping messages.
-    encode_client(&frame).expect("postcard encode of ClientFrame::PlayerState cannot fail")
+    encode_client(&frame)
 }
 
 /// Fill `buf` with approximately `len` bytes of deterministic-but-varied
@@ -123,7 +120,7 @@ pub fn fill_pseudo_user_data(buf: &mut Vec<u8>, len: usize, player_seed: u64, ti
     buf.extend_from_slice(&bytes);
 }
 
-/// Encode one `GAME_ACTION` frame as postcard bytes for the Arcane cluster
+/// Encode one `GAME_ACTION` frame as FlatBuffer bytes for the Arcane cluster
 /// WebSocket. `payload` is treated as opaque application bytes (typically
 /// the caller passes in JSON bytes).
 pub fn encode_game_action(entity_id: &uuid::Uuid, action_type: &str, payload: &[u8]) -> Vec<u8> {
@@ -132,7 +129,7 @@ pub fn encode_game_action(entity_id: &uuid::Uuid, action_type: &str, payload: &[
         action_type: action_type.to_string(),
         payload: payload.to_vec(),
     });
-    encode_client(&frame).expect("postcard encode of ClientFrame::Action cannot fail")
+    encode_client(&frame)
 }
 
 #[cfg(test)]

--- a/crates/arcane-swarm/src/protocol.rs
+++ b/crates/arcane-swarm/src/protocol.rs
@@ -34,17 +34,14 @@ pub fn encode_player_state(
     vy: f64,
     vz: f64,
     user_data: &[u8],
+    client_seq: u64,
 ) -> Vec<u8> {
-    // Quantize at the wire boundary: continuous f64 from the simulated
-    // player tick becomes i16 on the wire (~3-9 B per Vec3 vs 24 B). See
-    // arcane_wire::Vec3Q for the scale + range tradeoff. Sub-unit precision
-    // is lost; the benchmark world's noise floor (collision_radius=50) is
-    // well above 1 unit so this is invisible to the kinematic sim.
     let frame = ClientFrame::PlayerState(PlayerStatePayload {
         entity_id: *id,
         position: Vec3Q::from_vec3(WireVec3::new(x, y, z)),
         velocity: Vec3Q::from_vec3(WireVec3::new(vx, vy, vz)),
         user_data: user_data.to_vec(),
+        client_seq,
     });
     encode_client(&frame)
 }
@@ -140,7 +137,7 @@ mod tests {
     #[test]
     fn encode_player_state_roundtrips() {
         let id = uuid::Uuid::from_u128(0x1111_2222);
-        let bytes = encode_player_state(&id, 1.25, 2.5, 3.75, 0.1, 0.0, -0.1, &[]);
+        let bytes = encode_player_state(&id, 1.25, 2.5, 3.75, 0.1, 0.0, -0.1, &[], 0);
         let decoded = decode_client(&bytes).unwrap();
         let ClientFrame::PlayerState(payload) = decoded else {
             panic!("expected PlayerState variant");
@@ -156,7 +153,7 @@ mod tests {
     fn encode_player_state_carries_user_data() {
         let id = uuid::Uuid::from_u128(7);
         let payload = vec![0xAB, 0xCD, 0xEF, 0x12, 0x34];
-        let bytes = encode_player_state(&id, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, &payload);
+        let bytes = encode_player_state(&id, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, &payload, 0);
         let decoded = decode_client(&bytes).unwrap();
         let ClientFrame::PlayerState(p) = decoded else {
             panic!("expected PlayerState variant");

--- a/docs/SWARM_ORCHESTRATOR_DESIGN.md
+++ b/docs/SWARM_ORCHESTRATOR_DESIGN.md
@@ -6,12 +6,14 @@
 
 ## Why this exists
 
-Today's benchmark architecture grew organically:
+The benchmark harness grew organically (and still contains legacy scripts kept for emergencies):
 
-- A PowerShell harness running on the operator's laptop drives the run.
-- The harness fans out SSM `RunCommand` calls in parallel to N driver EC2 instances.
+- A PowerShell harness running on the operator's laptop drives *some* paths.
+- **Historical / internal-only path:** the harness fans out SSM `RunCommand` calls in parallel to N driver EC2 instances.
 - Each driver runs `arcane-swarm` in Docker; it executes a tier ramp and writes per-tier `FINAL` lines to stderr.
-- The harness pulls per-driver stderr from S3 *after* all drivers exit; aggregates; declares a winner.
+- In that historical path, the harness pulls per-driver stderr from S3 *after* all drivers exit; aggregates; declares a winner.
+
+**Supported public reproduction today:** start the fleet + orchestrator, then run local `benchmark-controller` against the orchestrator HTTP API (`Run-Benchmark-Aws-Controller.ps1`), which renders the real-time terminal dashboard by subscribing to orchestrator SSE. This design doc treats that controller/orchestrator split as the direction of travel even where legacy harness pieces still exist in-repo.
 
 This works, but it leaves three structural problems on the table that get worse as the benchmark suite expands:
 
@@ -189,7 +191,7 @@ For each component PR, the structure is:
 - **Mid-run dynamic driver scale-up.** Fleet is fixed at run start; scale-up requires its own design.
 - **Multi-region orchestration.** Single-region only; multi-region requires its own design.
 - **Driver provisioning.** Stays Terraform.
-- **Replacement of the existing PowerShell harness for non-orchestrated paths.** Standalone driver mode keeps the existing path alive during the controller rollout.
+- **Replacement of the legacy PowerShell harness for non-orchestrated paths.** Standalone driver mode keeps an internal-only harness alive during the controller rollout (not advertised as the public reproduction path).
 - **Authentication beyond VPC scoping.** Operator-laptop-to-orchestrator is plain HTTPS over a known instance ID; security group keeps it scoped to the operator's CIDR. Stronger auth (mTLS / JWT) is added when the deployment requires it.
 
 ## Delivery sequence
@@ -198,7 +200,7 @@ For each component PR, the structure is:
 2. **Component PRs**: command dispatch (C2) → stats collector (C3) → telemetry SSE (C5) → telemetry archive (C6). Each unignores its own tests; each is one agent task.
 3. **Driver protocol extension PR.** Adds `--orchestrator-url` and orchestrated-mode task to existing `arcane-swarm`.
 4. **Benchmark controller** (new crate in `arcane-scaling-benchmarks`): owns phase logic, drives the orchestrator. Tracked as a separate epic in that repo.
-5. **PowerShell harness shrink.** Existing `Run-Benchmark-Aws.ps1` becomes ~50 lines that reads Terraform output, launches the controller, launches `orchestrator-cli` for live view.
+5. **Operator launcher.** `Run-Benchmark-Aws-Controller.ps1` is the supported entrypoint: read Terraform `benchmark_state`, start the AWS-side containers, then run local `benchmark-controller` against the orchestrator HTTP API (terminal dashboard via controller SSE subscription).
 6. **Re-run the headline benchmark** end-to-end via controller → orchestrator → drivers; validate parity with prior baseline within 1%.
 
 ## Open decisions
@@ -216,4 +218,4 @@ The orchestrator is done when all six of these pass:
 3. Per-phase validity gate **in the benchmark controller** aborts a synthetic-failure run within 15s of breach.
 4. All acceptance tests across orchestrator components pass in CI.
 5. PowerShell harness shrunk to operator-cli launcher.
-6. README's "Reproduce in 10 minutes" still works end-to-end (now via controller → orchestrator instead of the old harness).
+6. The benchmark repo README's public reproduction path works end-to-end (controller → orchestrator → drivers).


### PR DESCRIPTION
## Summary

- Updates arcane-swarm for FlatBuffers wire format compatibility (arcane#166)
- Adds driver metrics pipeline — cumulative ok/err/latency counters reported through orchestrator telemetry
- Adds sequence-tagged RTT latency measurement (replaces last_send atomic approach)
- Raises fd soft limit at startup in swarm + orchestrator binaries
- Fixes DeltaCache key collision that caused zero latency samples after FlatBuffers migration
- Fixes arcane-wire path resolution for Docker builds

These changes are required by the benchmark-controller, which depends on `driver_metrics` in `TelemetrySnapshot` for gate evaluation and phase metrics.

## Test plan

- [x] Full 8-cluster benchmark run completed successfully with this branch
- [x] Driver metrics reported correctly through telemetry pipeline
- [x] Latency samples non-zero at all tiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)