### PR TITLE
docs: README covers both workspace crates and the two run modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,32 @@ This repository contains only swarm-specific code and packaging.
 
 ## Workspace
 
-- `crates/arcane-swarm` - swarm binary crate (`arcane-swarm`)
+- `crates/arcane-swarm` - load-driver binary crate (`arcane-swarm`): simulates game clients (WebSocket + SpacetimeDB SDK) against an Arcane or SpacetimeDB backend.
+- `crates/arcane-swarm-orchestrator` - orchestrator binary crate (`arcane-swarm-orchestrator`): central control plane for multi-driver runs — drivers register over a typed WebSocket protocol, receive phase commands, and stream telemetry back.
+
+## Modes
+
+- **Standalone**: run a single `arcane-swarm` driver directly with CLI flags — quick local load tests.
+- **Orchestrated**: drivers start with `--orchestrator-url` and zero players, then wait for commands; the orchestrator (driven by the benchmark controller in [arcane-scaling-benchmarks](https://github.com/brainy-bots/arcane-scaling-benchmarks)) sets player counts per phase. This is the mode every published benchmark uses.
 
 ## Build
 
 ```bash
-cargo build -p arcane-swarm --bin arcane-swarm --release
+cargo build --release
 ```
 
-## Run (example)
+## Run (examples)
 
 ```bash
 cargo run -p arcane-swarm --bin arcane-swarm -- --help
+cargo run -p arcane-swarm-orchestrator --bin arcane-swarm-orchestrator -- --help
 ```
 
 ## Architecture docs
 
 - [`docs/MODULE_INTERACTIONS.md`](docs/MODULE_INTERACTIONS.md) - crate/module responsibilities and Mermaid interaction graph.
 - [`docs/ENGINE_API_BOUNDARY.md`](docs/ENGINE_API_BOUNDARY.md) - reusable engine-facing API boundary for embedding/control tooling.
+- [`docs/SWARM_ORCHESTRATOR_DESIGN.md`](docs/SWARM_ORCHESTRATOR_DESIGN.md) - orchestrator control-plane design: protocol, registration, telemetry.
 - Library orchestration behavior is validated with mocked-backend tests in `crates/arcane-swarm/src/orchestration.rs`.
 
 ## License


### PR DESCRIPTION
## What

The public README listed only `crates/arcane-swarm`; the workspace has had `crates/arcane-swarm-orchestrator` (the control plane every published benchmark run uses) for a while — roughly a third of the codebase was undocumented at the top level.

- Added the orchestrator crate to the Workspace section with a one-line role description.
- Added a **Modes** section: standalone driver vs orchestrated (driver registers with `--orchestrator-url`, players start at 0, controller sets counts per phase) — and noted orchestrated is the published-benchmark mode.
- Linked `docs/SWARM_ORCHESTRATOR_DESIGN.md` which existed but was unreferenced.
- Both `--help` example commands verified running.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)